### PR TITLE
ADD : StoreList 컴포넌트 구현 완료

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,61 @@ interface IResponseError {
   message: string;
 }
 
+interface IResponse {
+  error_notices: IErrorNotice[];
+  error_risk_counts: IErrorRisk[];
+  robot_counts: IRobotError[];
+  robots: IRobots[];
+  statistics: IStatistics[];
+  stores: IStore[];
+}
+
+interface IErrorNotice {
+  created_at: string;
+  error_id: string;
+  format_date: string;
+  k_map_name: string;
+  error_msg: string;
+  log_id: string;
+  map_id: string;
+  map_name: string;
+  risk_degree: string;
+}
+
+interface IErrorRisk {
+  critical: string;
+  major: string;
+  map_id: string;
+  map_name: string;
+  minor: string;
+}
+
+interface IRobotError {
+  error: string;
+  map_id: string;
+  map_name: string;
+  refair: string;
+  serving: string;
+  stay: string;
+}
+
+interface IRobot {
+  avg_serving_time: string;
+  battery: string;
+  created_at: string;
+  destination: string;
+  map_id: string;
+  map_name: string;
+  move_distance: string;
+  performance: string;
+  power_on_time: string;
+  robot_id: string;
+  serving_count: string;
+  state: string;
+  x_pos: string;
+  y_pos: string;
+}
+
 interface IStatistics {
   avg_serving_time: string;
   avg_serving_time_before: string;
@@ -41,4 +96,29 @@ interface IStatistics {
   performance_before: string;
   serving_count: string;
   serving_count_before: string;
+}
+
+interface IStore {
+  created_at: string;
+  descirbe: string;
+  error: string;
+  error_count: string;
+  home: string;
+  img_src: string;
+  location: string;
+  login: string;
+  map_id: string;
+  map_name: string;
+  performance: string;
+  refair: string;
+  serving: string;
+  serving_count: string;
+  start_dir: string;
+  start_node: string;
+  stay: string;
+  store_lat: string;
+  store_lng: string;
+  total: number;
+  wifi_id: string;
+  wifi_pw: string;
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,24 +6,27 @@ import LogoText from '../public/assets/images/image_logo.png';
 import Statistics from '@src/components/Home/Statistics/Statistics';
 import homeAPI from '@src/api/home';
 import { IServing } from '@src/types/home';
+import StoreList from '@src/components/Home/StoreList/StoreList';
 
 export async function getServerSideProps() {
   const serving = await homeAPI.getServing();
 
+  const stores = await homeAPI.getStores();
+
   return {
     props: {
       serving: serving,
+      stores: stores,
     },
   };
 }
 
 interface IProps {
   serving: IServing;
+  stores: IResponse;
 }
 
-const Home = ({ serving }: IProps) => {
-  console.log(serving);
-
+const Home = ({ serving, stores }: IProps) => {
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
       <StHome>
@@ -35,15 +38,18 @@ const Home = ({ serving }: IProps) => {
         </StHeader>
         <StBody>
           <Statistics serving={serving.all} />
+          <StoreList stores={stores.stores} />
         </StBody>
-        <StFooter></StFooter>
       </StHome>
     </motion.div>
   );
 };
 
 const StHome = styled.div`
+  padding-bottom: 10vh;
   width: 100%;
+  background: ${({ theme }) => theme.color.background};
+  overflow: scroll;
 `;
 
 const StHeader = styled.header`
@@ -67,10 +73,6 @@ const StImage = styled(Image)`
 
 const StBody = styled.main`
   padding: 0 20px;
-  width: 100%;
-`;
-
-const StFooter = styled.footer`
   width: 100%;
 `;
 

--- a/src/components/Common/Title.tsx
+++ b/src/components/Common/Title.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { MdArrowForwardIos } from 'react-icons/md';
+
+interface IProps {
+  title: string;
+  event: () => void;
+}
+
+const Title = ({ title, event }: IProps) => {
+  return (
+    <StTitle>
+      <StText>{title}</StText>
+      <StIcon onClick={event} />
+    </StTitle>
+  );
+};
+
+const StTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StText = styled.p`
+  margin-top: 1px;
+  color: ${({ theme }) => theme.color.gray700};
+  font-size: 18px;
+  font-weight: 600;
+`;
+
+const StIcon = styled(MdArrowForwardIos)`
+  width: 25px;
+  height: 25px;
+  color: ${({ theme }) => theme.color.gray500};
+`;
+
+export default Title;

--- a/src/components/Common/TopNav.tsx
+++ b/src/components/Common/TopNav.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { IoArrowBack } from 'react-icons/io5';
+import { MdArrowBackIos } from 'react-icons/md';
 
 interface IProps {
   text: string;
@@ -18,7 +18,7 @@ const TopNav = ({ text }: IProps) => {
       <StBody>
         <StTitle>{text}</StTitle>
         <StIcon>
-          <IoArrowBack onClick={handleBackClick} size={30} />
+          <MdArrowBackIos onClick={handleBackClick} size={25} />
         </StIcon>
       </StBody>
     </StTopNav>

--- a/src/components/Home/Statistics/StatisticsInfo.tsx
+++ b/src/components/Home/Statistics/StatisticsInfo.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import React from 'react';
 import { RiArrowDownSFill, RiArrowUpSFill } from 'react-icons/ri';
 
 interface IProps {

--- a/src/components/Home/StoreList/Store.tsx
+++ b/src/components/Home/StoreList/Store.tsx
@@ -1,0 +1,129 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import React from 'react';
+
+interface IProps {
+  store: IStore;
+}
+
+const Store = ({ store }: IProps) => {
+  const { img_src, map_name, stay, refair, total, serving_count, error_count, performance } = store;
+
+  const STATUS = [
+    { id: 0, color: 'main', count: parseInt(error_count) },
+    { id: 1, color: 'sub', count: parseInt(serving_count) },
+    { id: 2, color: 'stroke', count: parseInt(refair) },
+    { id: 3, color: 'light', count: parseInt(stay) },
+  ];
+
+  const STATISTICS = [
+    { id: 0, title: '서빙횟수', count: serving_count },
+    { id: 1, title: '에러횟수', count: error_count },
+    { id: 2, title: '주행효율', count: performance ? performance : '측정불가' },
+  ];
+
+  const widthHandler = (count: number, total: number) => {
+    return (count / total) * 100;
+  };
+
+  return (
+    <StStore>
+      <StBody>
+        <StStoreInfo>
+          <Image src={img_src} width={60} height={40} alt="매장이미지" />
+          <StStoreName>{map_name}</StStoreName>
+        </StStoreInfo>
+        <StStatisticsBox>
+          {STATISTICS.map(({ id, title, count }) => (
+            <StStatistics key={id}>
+              <StCount>{count}</StCount>
+              <StTitle>{title}</StTitle>
+            </StStatistics>
+          ))}
+        </StStatisticsBox>
+      </StBody>
+      <StFooter>
+        {STATUS.map(({ id, color, count }) => (
+          <StBarChart key={id} color={color} style={{ width: widthHandler(count, total) }} />
+        ))}
+      </StFooter>
+    </StStore>
+  );
+};
+
+const StStore = styled.div`
+  padding: 15px 5px;
+  width: 100%;
+  background: white;
+  border-radius: 5px;
+  cursor: pointer;
+
+  :hover {
+    background: ${({ theme }) => theme.color.gray100};
+  }
+`;
+
+const StBody = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StStoreInfo = styled.div`
+  width: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  border-right: ${({ theme }) => `1px solid ${theme.color.gray300}`};
+`;
+
+const StStoreName = styled.p`
+  margin-top: 5px;
+  font-size: 10px;
+`;
+
+const StStatisticsBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StStatistics = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  gap: 5px;
+`;
+
+const StCount = styled.p`
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const StTitle = styled.p`
+  font-size: 14px;
+  color: ${({ theme }) => theme.color.gray600};
+`;
+
+const StFooter = styled.footer`
+  margin: 0 auto;
+  margin-top: 10px;
+  display: flex;
+  width: 90%;
+  height: 5px;
+  border-radius: 5px;
+  background: ${({ theme }) => theme.color.light};
+  overflow: hidden;
+`;
+
+const StBarChart = styled.div<{ color: string }>`
+  height: 5px;
+  background: ${({ theme, color }) => theme.color[color]};
+`;
+
+export default Store;

--- a/src/components/Home/StoreList/StoreList.tsx
+++ b/src/components/Home/StoreList/StoreList.tsx
@@ -1,0 +1,121 @@
+import styled from '@emotion/styled';
+import React, { useState } from 'react';
+import Title from '../../Common/Title';
+import { useRouter } from 'next/router';
+import { ERROR_STATUS } from '@src/mocks/ERROR_STATUS';
+import { IErrorStatus } from '@src/types/home';
+import Store from './Store';
+
+interface IProps {
+  stores: IStore[];
+}
+
+const StoreList = ({ stores }: IProps) => {
+  const [showMore, setShowMore] = useState<boolean>(false);
+
+  const router = useRouter();
+
+  const end = showMore ? 6 : 3;
+
+  const pageHandler = () => {
+    router.push('/store');
+  };
+
+  const organizedStores = stores.map((store: IStore) => ({
+    ...store,
+    total: parseInt(store.error) + parseInt(store.serving) + parseInt(store.stay) + parseInt(store.refair),
+  }));
+
+  return (
+    <StStoreList>
+      <StHeader>
+        <Title title="전체 매장" event={pageHandler} />
+        <StStatusBox>
+          {ERROR_STATUS.map(({ id, status, color }: IErrorStatus) => (
+            <StFlexBox key={id}>
+              <StColor status={status} color={color} />
+              <StStatus>{status}</StStatus>
+            </StFlexBox>
+          ))}
+        </StStatusBox>
+      </StHeader>
+      <StBody>
+        {organizedStores.slice(0, end).map((store: IStore, idx: number) => (
+          <Store key={idx} store={store} />
+        ))}
+      </StBody>
+      <StFooter
+        onClick={() => {
+          setShowMore(!showMore);
+        }}>
+        {showMore ? '접기' : '더 보기 '}
+      </StFooter>
+    </StStoreList>
+  );
+};
+
+const StStoreList = styled.div`
+  margin-top: 50px;
+  width: 100%;
+`;
+
+const StHeader = styled.header`
+  width: 100%;
+`;
+
+const StStatusBox = styled.div`
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  gap: 10px;
+`;
+
+const StFlexBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+`;
+
+const StColor = styled.div<{ color: string; status: string }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: ${({ status }) => status === '수리' && '1px solid black'};
+  background: ${({ theme, color }) => theme.color[color]};
+`;
+
+const StStatus = styled.p`
+  margin-top: 1px;
+  font-size: 10px;
+`;
+
+const StBody = styled.main`
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+`;
+
+const StFooter = styled.button`
+  display: block;
+  margin: 0 auto;
+  margin-top: 10px;
+  width: 100px;
+  height: 30px;
+  color: ${({ theme }) => theme.color.gray500};
+  background: ${({ theme }) => theme.color.white};
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+
+  :hover {
+    background: ${({ theme }) => theme.color.gray100};
+  }
+`;
+
+export default StoreList;

--- a/src/mocks/ERROR_STATUS.tsx
+++ b/src/mocks/ERROR_STATUS.tsx
@@ -1,0 +1,8 @@
+import { IErrorStatus } from '@src/types/home';
+
+export const ERROR_STATUS: IErrorStatus[] = [
+  { id: 0, status: '에러', color: 'main' },
+  { id: 1, status: '서빙', color: 'sub' },
+  { id: 2, status: '대기', color: 'stroke' },
+  { id: 3, status: '수리', color: 'light' },
+];

--- a/src/mocks/Sample.tsx
+++ b/src/mocks/Sample.tsx
@@ -1,8 +1,0 @@
-//하단 코드 지우고 작성 시작
-import React from 'react';
-
-const Sample = () => {
-  return <div></div>;
-};
-
-export default Sample;

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -23,3 +23,9 @@ export type IDateTab = {
   주간: JSX.Element;
   월간: JSX.Element;
 };
+
+export type IErrorStatus = {
+  id: number;
+  status: string;
+  color: string;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 헬퍼로보틱스와 협업을 맺은 가게들을 리스팅하고 각 매장에서 가용중인 로봇에서 일어난 에러, 서빙, 대기, 수리, 주행효율을 표시

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 가게 리스팅
- 매장을 리스팅 할 때 총 6개의 가게들이 리스팅 되는데 여러가지 복잡한 데이터가 섞여있는 관제시스템인 특성 상 만큼 되도록 간결해야 한다고 판단
- showMore이라는 boolean값 useState를 생성하고 버튼을 만들어 버튼을 누를때마다 boolean 값을 반대로 바꿔주는 setState 함수를 버튼 이벤트에 바인딩
- true일때는 6개의 가게들이 모두 리스팅되고 버튼의 텍스트는 '접기' 로 변경, false 일때는 3개의 매장만 리스팅하고 텍스트는 '더보기'로 변경  
- 초깃값은 false로 3개만 리스팅

2. 이슈의 시각화
- 에러, 수리, 서빙, 대기 데이터를 가독성있게 보여주기 위해 바형식으로 데이터 시각화 진행
- 서버로부터 내려오는 기존 데이터는 total 이라는 항목이 없어서 oraganizedStores 라는 변수를 생성하고 각각의 매장에서 일어난 이슈들의 총합인 total 항목 추가
- (count(각각의 이슈) / total) x 100의 연산으로 퍼센티지로 수치화하고 width 값에 넣음