### PR TITLE
ADD : DropDown 컴포넌트 구현 완료

### DIFF
--- a/src/components/Common/DropDown.tsx
+++ b/src/components/Common/DropDown.tsx
@@ -1,0 +1,96 @@
+import styled from '@emotion/styled';
+import useOnClickOutside from '@src/hooks/useOnClickOutside';
+import React, { useRef, useState } from 'react';
+
+interface IProps {
+  selected: any;
+  list: any;
+  event: any;
+}
+
+const DropDown = ({ selected, list, event }: IProps) => {
+  const [isOpen, setisOpen] = useState<boolean>(false);
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const dropdownHandler = () => {
+    setisOpen(!isOpen);
+  };
+
+  useOnClickOutside(ref, () => {
+    setisOpen(false);
+  });
+
+  return (
+    <StDropdown ref={ref}>
+      <StSelected isOpen={isOpen} onClick={dropdownHandler}>
+        {selected}
+      </StSelected>
+      <StSelect isOpen={isOpen}>
+        {list.map(({ id, option }: any) => (
+          <StOption key={id} onClick={event}>
+            {option}
+          </StOption>
+        ))}
+      </StSelect>
+    </StDropdown>
+  );
+};
+
+const StDropdown = styled.div`
+  position: relative;
+`;
+
+const StSelected = styled.button<{ isOpen: boolean }>`
+  position: relative;
+  padding: 0 5px;
+  width: 120px;
+  height: 30px;
+  background: ${({ theme, isOpen }) => (isOpen ? theme.color.main : theme.color.sub)};
+  color: ${({ theme }) => theme.color.white};
+  border: none;
+  border-radius: 5px;
+  border-bottom-left-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
+  border-bottom-right-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
+  font-size: 11px;
+  z-index: 2;
+  cursor: pointer;
+
+  :hover {
+    background: ${({ theme }) => theme.color.main};
+  }
+`;
+
+const StSelect = styled.div<{ isOpen: boolean }>`
+  position: absolute;
+  top: 30px;
+  left: 0px;
+  width: 120px;
+  border-radius: 5px;
+  border-top-left-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
+  border-top-right-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+  translate: ${({ isOpen }) => (isOpen ? '0' : '0 -30px')};
+  transition: 0.4s;
+  overflow: hidden;
+  z-index: 1;
+`;
+
+const StOption = styled.button`
+  padding: 0 5px;
+  width: 120px;
+  height: 30px;
+  background: ${({ theme }) => theme.color.sub};
+  color: ${({ theme }) => theme.color.white};
+  border: 0;
+  border-bottom: ${({ theme }) => `0.1px solid ${theme.color.white}`};
+  cursor: pointer;
+  font-size: 10px;
+
+  :hover {
+    background: ${({ theme }) => theme.color.main};
+  }
+`;
+
+export default DropDown;

--- a/src/hooks/Sample.tsx
+++ b/src/hooks/Sample.tsx
@@ -1,8 +1,0 @@
-//하단 코드 지우고 작성 시작
-import React from 'react';
-
-const Sample = () => {
-  return <div></div>;
-};
-
-export default Sample;

--- a/src/hooks/useOnClickOutside.tsx
+++ b/src/hooks/useOnClickOutside.tsx
@@ -1,0 +1,21 @@
+import { MouseEventHandler, RefObject, useEffect } from 'react';
+
+const useOnClickOutside = (ref: RefObject<HTMLDivElement>, handler: MouseEventHandler<HTMLButtonElement>) => {
+  useEffect(() => {
+    const listener = (event: any) => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      handler(event);
+    };
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+};
+
+export default useOnClickOutside;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 드롭다운으로 옵션들을 리스팅하여 사용자로 하여금 편하게 페이지 이동이나 데이터 필터링이 가능하도록 구현할 계획
- 현재는 드롭다운에 필요한 필수적인 요소들로 구성했고 타입은 임시로 any를 지정
- 추후에 데이터를 내리면서 정확한 타입 지정 예정 

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. useOnClickOutside 커스텀 훅을 만들어 드롭다운 기능 구현
- 드롭다운의 밖을 클릭 했을 시 이를 감지하고 드롭다운이 비활성화( 내려왔던 리스트들을 다시 원래대로 올리는 ) 기능을 하는 함수가 필요하기 때문에 이를 커스텀 훅으로 빼서 작업.
- useOnClickOutside는 외부 클릭 이벤트를 감지하여 특정 요소 이외의 영역을 클릭했을 때 지정된 콜백 함수를 실행하는 Hook.
- 드롭다운을 감싸는 최상위 요소에 ref를 지정해주고 이 요소 이외의 영역을 클릭하면 useOnClickOutside의 handler 함수가 실행.
- useEffect 함수를 이용하여 드롭다운이 렌더링될 때 외부 클릭 이벤트를 감지하는 리스너 함수를 등록하여 구현.