### PR TITLE
ADD : Risk Degree 컴포넌트 구현 완료

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,23 +1,22 @@
-import Image from 'next/image';
-import LogoIcon from 'public/assets/icons/icon_logo.png';
-import LogoText from 'public/assets/images/image_logo.png';
 import Statistics from '@src/components/Home/Statistics/Statistics';
 import homeAPI from '@src/api/home';
 import StoreList from '@src/components/Home/StoreList/StoreList';
-import KakaoMap from '@src/components/Store/KakaoMap';
-import { IServing } from '@src/types/home';
-import { motion } from 'framer-motion';
+import { IRecentErrors, IServing } from '@src/types/home';
 import styled from '@emotion/styled';
+import RecentError from '@src/components/Home/RecentError/RecentError';
 
 export async function getServerSideProps() {
   const serving = await homeAPI.getServing();
 
   const stores = await homeAPI.getStores();
 
+  const errors = await homeAPI.getRecentErrors();
+
   return {
     props: {
       serving: serving,
       stores: stores,
+      errors: errors,
     },
   };
 }
@@ -25,14 +24,18 @@ export async function getServerSideProps() {
 interface IProps {
   serving: IServing;
   stores: IResponse;
+  errors: IRecentErrors;
 }
 
-const Home = ({ serving, stores }: IProps) => {
+const Home = ({ serving, stores, errors }: IProps) => {
+  console.log(errors);
+
   return (
     <StHome>
       <StBody>
         <Statistics serving={serving.all} />
         <StoreList stores={stores.stores} />
+        <RecentError errors={errors.error_notice} />
       </StBody>
     </StHome>
   );

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -1,8 +1,7 @@
 const API = {
   getServing: '/api/monitoring-system/statistic',
   getStores: '/api/monitoring-system/store',
-  getErrorStatus: '/api/monitoring-system/risk_count',
-  getAllErrors: '/api/monitoring-system/error-notice/all',
+  getRecentErrors: '/api/monitoring-system/error-notice/all',
   postDates: '/api/monitoring-system/error-notice/by-time',
   getRobots: '/api/monitoring-system/robot?state=',
   getRobotsDetail: '/api/monitoring-system/robot/map_id',

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -8,11 +8,8 @@ const homeAPI = {
   getStores: () => {
     return client.get(`${API.getStores}`);
   },
-  getErrorStatus: () => {
-    return client.get(`${API.getErrorStatus}`);
-  },
-  getAllErrors: () => {
-    return client.get(`${API.getAllErrors}`);
+  getRecentErrors: () => {
+    return client.get(`${API.getRecentErrors}`);
   },
   postDates: (data: any) => {
     return client.post(`${API.postDates}`, data);

--- a/src/components/Home/RecentError/RecentError.tsx
+++ b/src/components/Home/RecentError/RecentError.tsx
@@ -1,0 +1,89 @@
+import Title from '@src/components/Common/Title';
+import RiskDegree from './RiskDegree';
+import { IRiskDegree, IRiskDegreeList } from '@src/types/home';
+import styled from '@emotion/styled';
+
+interface IProps {
+  errors: IErrorNotice[];
+}
+
+const RecentError = ({ errors }: IProps) => {
+  const riskDegree: IRiskDegree = errors.reduce(
+    (acc: IRiskDegree, { risk_degree }) => {
+      acc['all'] = acc['all'] + 1;
+      acc[risk_degree] = acc[risk_degree] + 1;
+      return acc;
+    },
+    { all: 0, minor: 0, major: 0, critical: 0 },
+  );
+
+  const riskDegreeList: IRiskDegreeList[] = Object.entries(riskDegree).map(([degree, count], id) => ({
+    id,
+    degree,
+    count,
+  }));
+
+  return (
+    <StRecentError>
+      <StHeader>
+        <Title title="최근 에러" />
+        <StDegreeBox>
+          {riskDegreeList.map(({ id, degree }) => (
+            <StFlexBox key={id}>
+              <StColor color={degree} />
+              <StDegree>{degree[0].toUpperCase() + degree.slice(1)}</StDegree>
+            </StFlexBox>
+          ))}
+        </StDegreeBox>
+      </StHeader>
+      <StBody>
+        <RiskDegree riskDegreeList={riskDegreeList} />
+      </StBody>
+    </StRecentError>
+  );
+};
+
+const StRecentError = styled.div`
+  margin-top: 60px;
+  width: 100%;
+`;
+
+const StHeader = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StDegreeBox = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 30px;
+  gap: 20px;
+`;
+
+const StFlexBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+`;
+
+const StColor = styled.div<{ color: string }>`
+  width: 10px;
+  height: 10px;
+  background: ${({ theme, color }) => theme.color[color]};
+  border: ${({ color }) => color === 'all' && '1px solid black'};
+  border-radius: 10px;
+`;
+
+const StDegree = styled.p`
+  font-size: 12px;
+`;
+
+const StBody = styled.main`
+  margin-top: 30px;
+  width: 100%;
+`;
+
+export default RecentError;

--- a/src/components/Home/RecentError/RiskDegree.tsx
+++ b/src/components/Home/RecentError/RiskDegree.tsx
@@ -1,0 +1,55 @@
+import { IRiskDegreeList } from '@src/types/home';
+import styled from '@emotion/styled';
+
+interface IProps {
+  riskDegreeList: IRiskDegreeList[];
+}
+
+const RiskDegree = ({ riskDegreeList }: IProps) => {
+  return (
+    <StRiskDegree>
+      <StBody>
+        {riskDegreeList.map(({ id, degree, count }) => (
+          <StRiskDegreeBox key={id}>
+            <StDegree>{degree[0].toUpperCase() + degree.slice(1)}</StDegree>
+            <StCount>{count}</StCount>
+          </StRiskDegreeBox>
+        ))}
+      </StBody>
+    </StRiskDegree>
+  );
+};
+
+const StRiskDegree = styled.div`
+  padding: 10px 20px;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 5px;
+`;
+
+const StBody = styled.main`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StRiskDegreeBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+`;
+
+const StDegree = styled.p`
+  color: ${({ theme }) => theme.color.gray600};
+  font-size: 14px;
+`;
+
+const StCount = styled.p`
+  color: ${({ theme }) => theme.color.gray700};
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+export default RiskDegree;

--- a/src/components/Home/StoreList/StoreList.tsx
+++ b/src/components/Home/StoreList/StoreList.tsx
@@ -74,12 +74,6 @@ const StHeader = styled.header`
   width: 100%;
 `;
 
-const StTitle = styled.h1`
-  color: ${({ theme }) => theme.color.gray700};
-  font-size: 18px;
-  font-weight: 600;
-`;
-
 const StStatusBox = styled.div`
   display: flex;
   justify-content: flex-start;

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -24,6 +24,24 @@ export type IDateTab = {
   월간: JSX.Element;
 };
 
+export type IRecentErrors = {
+  error_notice: IErrorNotice[];
+};
+
+export type IRiskDegreeList = {
+  id: number;
+  degree: string;
+  count: number;
+};
+
+export type IRiskDegree = {
+  [key: string]: number;
+  all: number;
+  minor: number;
+  major: number;
+  critical: number;
+};
+
 export type IErrorStatus = {
   id: number;
   status: string;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 최근 에러 100개 중 각각의 에러의 위험 정도를 minor, major, critical 로 구분하고 각각을 카운팅해 렌더링하는 Risk Degree 컴포넌트 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Risk Degree 카운팅하기
- 서버에서 보내주는 데이터의 형식은 아래와 같다.

 [
    {error_id: "119734", robot_id: "4",risk_degree : "major"}, 
    {error_id: "119734", robot_id: "4",risk_degree : "minor"},  
    {error_id: "119734", robot_id: "4",risk_degree : "critical"},
    ...
]

- 위의 데이터를 가공해서 risk_degree라는 요소만 추출한 후 각각 몇 번이나 발생했는지 카운팅 하고 이를 mapping 하기 위해 배열로 만들어야 한다. 원하는 데이터의 형식은 아래와 같다.

[
    {id: 0, degree: 'all', count: 3},
    {id: 1, degree: 'minor', count: 1},
    {id: 2, degree: 'major', count: 1},
    {id: 3, degree: 'critical', count: 1}
]

- 먼저 각각의 위험 정도를 카운팅 하기 위해 reduce 함수를 이용해 객체 형식으로 {all: 3, minor: 1, major: 1, critical: 1} 와 같이 변환
- 위에서 reduce 함수를 통해  만든 객체를 배열로 변환하고 id, degree, count 요소를 넣기 위해 Object.entries 와 map을 이용해 데이터 가공 진행.