### PR TITLE
ADD : useInfiniteScroll 커스텀 훅 구현

### DIFF
--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -1,0 +1,56 @@
+import { RefObject, useEffect, useState } from 'react';
+
+const useInfiniteScroll = (initialData: IErrorNotice[], ref: RefObject<HTMLDivElement>) => {
+  const [isLoading, setisLoading] = useState<boolean>(false);
+  const [data, setData] = useState<IErrorNotice[]>([]);
+
+  useEffect(() => {
+    setData(initialData.slice(0, 20));
+  }, [initialData]);
+
+  const loadMoreData = () => {
+    setisLoading(true);
+
+    setTimeout(() => {
+      const updatedData = initialData.slice(0, data.length + 20);
+      setData(updatedData);
+      setisLoading(false);
+    }, 500);
+  };
+
+  useEffect(() => {
+    const container = ref.current;
+
+    if (!container) return;
+
+    const options = {
+      rootMargin: '0px',
+      threshold: 1,
+    };
+
+    const handleObserver = (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+
+      if (target.isIntersecting && data.length < initialData.length) {
+        setisLoading(true);
+        loadMoreData();
+      }
+    };
+
+    const observer = new IntersectionObserver(handleObserver, options);
+
+    if (container) {
+      observer.observe(container);
+    }
+
+    return () => {
+      if (container) {
+        observer.unobserve(container);
+      }
+    };
+  }, [data]);
+
+  return { data, isLoading };
+};
+
+export default useInfiniteScroll;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로봇에서 발생한 에러 로그들을 map을 통해 리스팅 할 경우 그 갯수가 최소 2-3000개가 넘어가면서 웹 페이지 과부하 발생
- 성능최적화를 위해 intersection Observer API를 사용한 무한스크롤 커스텀 훅 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. useInfiniteScroll
- 무한 스크롤을 처리하는 커스텀 훅. 
- 초기 데이터(initialData)와 스크롤을 감지할 div 요소의 ref를 매개변수로 받는다. 
- isLoading과 data를 리턴.

2. useInfiniteScroll - useState
- isLoading과 data 상태를 정의. 
- isLoading은 데이터를 추가로 로드하는 동안 로딩 상태를 나타내는 불리언 값. 
- data는 현재까지 렌더링 된 에러 로그 데이터 배열.

3. useInfiniteScroll - loadMoreData
- 추가 데이터를 로드하는 함수. 
- 서버쪽에서 페이지네이션을 작업할 상황이 되지 않았기에 클라이언트 단에서 데이터 배열을 자르고 붙이는 형태로 구현.
- 로딩 상태를 true로 설정하고, 500ms의 딜레이 후 추가 데이터를 가져와서 data 상태를 업데이트 후 로딩 상태를 다시 false로 설정.

4. useInfiniteScroll - useEffect (1)
- 초기 데이터 설정을 위한 useEffect
- 처음에 유저에게 보여줄 20개의 데이터가 필요하기 때문에 initialData.slice(0,20) 으로 초기 데이터 렌더링

6. useInfiniteScroll - useEffect (2)
- ref를 사용하여 스크롤을 감지하고 무한 스크롤을 처리. 
- container 변수를 통해 ref.current 값을 가져오며 만약 이 값이 없다면 함수를 종료.

7. useInfiniteScroll - useEffect (2) - handleObserver
- IntersectionObserver의 콜백 함수
- 관찰 대상의 isIntersecting 속성을 확인하여 보여지는 영역에 진입했는지 검사하고, data의 길이가 초기 데이터의 전체 길이보다 작을 때 데이터를 추가로 로드.(target.isIntersecting && data.length < initialData.length)

8. useInfiniteScroll - useEffect (2) - options
- rootMargin을 '0px'로 설정하여 관찰 대상 요소가 뷰포트와 교차하는 순간을 감지.
- threshold는 1로 설정하여 마지막 요소가 전부 보여졌을 때 다음 데이터가 로드되도록 설정.
