### PR TITLE
ADD : RecentError 컴포넌트 구현

### DIFF
--- a/src/components/Common/Error.tsx
+++ b/src/components/Common/Error.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled';
+import { MdArrowForwardIos } from 'react-icons/md';
+
+const Error = ({ error_msg, created_at, k_map_name, risk_degree, error_id }: IErrorNotice) => {
+  return (
+    <StError>
+      <StHeader color={risk_degree}></StHeader>
+      <StBody>
+        <StErrorMessage>{error_msg.split(',').join(', ')}</StErrorMessage>
+        <StFlexBox>
+          <StStoreName>{k_map_name}</StStoreName>
+          <StTime>{created_at}</StTime>
+        </StFlexBox>
+      </StBody>
+      <StFooter>
+        <StIcon size={20} />
+      </StFooter>
+    </StError>
+  );
+};
+
+const StError = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+  width: 100%;
+  height: 70px;
+  border: ${({ theme }) => `1px solid ${theme.color.gray400}`};
+  border-radius: 5px;
+  gap: 10px;
+  cursor: pointer;
+
+  :hover {
+    background: ${({ theme }) => theme.color.gray100};
+  }
+
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const StHeader = styled.header<{ color: string }>`
+  width: 5%;
+  height: 70px;
+  background: ${({ theme, color }) => theme.color[color]};
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+`;
+
+const StBody = styled.main`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
+const StErrorMessage = styled.p`
+  font-size: 14px;
+`;
+
+const StFlexBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const StStoreName = styled.p`
+  color: ${({ theme }) => theme.color.gray700};
+  font-size: 12px;
+`;
+
+const StTime = styled.p`
+  color: ${({ theme }) => theme.color.gray700};
+  font-size: 10px;
+`;
+
+const StFooter = styled.footer`
+  width: 10%;
+`;
+
+const StIcon = styled(MdArrowForwardIos)`
+  color: ${({ theme }) => theme.color.gray500};
+`;
+
+export default Error;

--- a/src/components/Common/Spinner.tsx
+++ b/src/components/Common/Spinner.tsx
@@ -16,7 +16,7 @@ const StSpinner = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  --uib-size: 2.0833vw;
+  --uib-size: 30px;
   --uib-speed: 0.8s;
   --uib-color: ${({ theme }) => theme.color.main};
   display: inline-block;

--- a/src/components/Home/RecentError/RecentErrorList.tsx
+++ b/src/components/Home/RecentError/RecentErrorList.tsx
@@ -1,0 +1,53 @@
+import { RefObject } from 'react';
+import Error from '@src/components/Common/Error';
+import Spinner from '@src/components/Common/Spinner';
+import styled from '@emotion/styled';
+
+interface IProps {
+  data: IErrorNotice[];
+  isLoading: boolean;
+  observerRef: RefObject<HTMLDivElement>;
+}
+
+const RecentErrorList = ({ data, isLoading, observerRef }: IProps) => {
+  return (
+    <StRecentErrorList>
+      <StBody>
+        {data.map((cur, idx) => (
+          <Error key={idx} {...cur} />
+        ))}
+        {isLoading && (
+          <StSpinnerBox>
+            <Spinner />
+          </StSpinnerBox>
+        )}
+        <div ref={observerRef} />
+      </StBody>
+    </StRecentErrorList>
+  );
+};
+
+const StRecentErrorList = styled.div`
+  margin-top: 20px;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 5px;
+`;
+
+const StBody = styled.main`
+  padding: 20px;
+  width: 100%;
+  height: 300px;
+  overflow: scroll;
+
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const StSpinnerBox = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export default RecentErrorList;

--- a/src/store/Sample.tsx
+++ b/src/store/Sample.tsx
@@ -1,8 +1,0 @@
-//하단 코드 지우고 작성 시작
-import React from 'react';
-
-const Sample = () => {
-  return <div></div>;
-};
-
-export default Sample;

--- a/src/store/recentErrors.ts
+++ b/src/store/recentErrors.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const recentErrorsState = atom<IErrorNotice[]>({
+  key: 'recentErrorsState',
+  default: [],
+});

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -54,3 +54,7 @@ export type IMap = {
   store_lat: string;
   store_lng: string;
 };
+
+export type ITimeMap = {
+  [index: number]: number;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Home 페이지의 최근 에러와 관련된 Recent Error 컴포넌트 구현
- 최신 데이터를 유지하기 위해 refetchInterval에 refetchTime을 동적으로 할당
- 웹 성능 최적화를 위한 무한스크롤 적용

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 공용 컴포넌트 Error
- 해당 컴포넌트는 에러 메시지와 생성 일자, 맵 이름, 위험 정도, 에러 ID와 같은 정보를 표시
- 추후 에러 페이지에서도 사용할 컴포넌트이기 때문에 Component에 Common 폴더 아래에 생성

2. RecentErrorList
- 공용 컴포넌트인 Error를 map 함수를 통해 리스팅하는 컴포넌트
- 해당 에러 메세지를 클릭하면 에러 상세 페이지로 넘어갈 수 있게끔 추후 함수를 연결할 예정

3. 최신 데이터를 유지하기 위한 refetchTime 동적 할당
- 해당 컴포넌트의 특성상 실시간으로 발생하는 에러 로그들을 받아오기 위해 Soket.io나 SSE 방식이 제일 적합하다고 판다하였으나 서버쪽에서 해당 기능을 구현할 리소스가 부족
- Soket.io나 SSE 등을 이용해 실시간으로 데이터를 받아오는 방법 대신 react-query의 refetch 기능을 활용하기로 결정.
- refetch 시간 설정을 1초, 3초, 5초 등 고정적인 시간을 할당하는 것은 에러가 잘 발생하지 않는 시간 대에서는 너무나 비효율적이고 수많은 요청으로 서버에 과부하가 걸릴 것을 우려.
- 가장 최근에 발생한 에러와 두 번째 발생한 에러의 시간 차를 계산하고 시간 차가 얼마 나지 않았을 때는 또 다시 에러가 발생할 확률이 높기 때문에 비교적 짧은 시간으로 리패칭 할 수 있도록 refetchTime 을 관리하는 timeMap이라는 obj을 생성하고 발생한 시간 차에 맞게 객체 매핑을 통해 refetchTime을 할당.
- 반대로 시간 차가 많이 날 경우 후에 에러가 일어날 확률이 상대적으로 적기 때문에 조금 더 긴 시간으로 리패칭할 수 있도록 refetchTime 설정
- 최대한 빠르게 발생한 에러를 비교적 실시간으로 렌더링 해야하기 때문에 최대 refetching 하는 주기를 30초가 넘지 않도록 설정.
- 첫 번째 에러와 두 번째 에러의 시간차가 얼마 나지 않아 refetchTime이 5초로 설정된 상태에서 이 후 에러가 몇 시간이나 발생하지 않는다면 아무런 의미 없이 5초의 주기로 계속해서 서버로 요청을 보내게 되므로 현재 시간과 가장 최근에 발생한 에러의 시간 차를 계산해 만약 5분을 넘었다면 refetching 하는 주기를 5초에서 30초로 변경되도록 설정