### PR TITLE
ADD : Robot 페이지 구현 완료

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Statistics from '@src/components/Home/Statistics/Statistics';
 import homeAPI from '@src/api/home';
 import StoreList from '@src/components/Home/StoreList/StoreList';
-import { IRecentErrors, IServing } from '@src/types/home';
+import { IServing } from '@src/types/home';
 import styled from '@emotion/styled';
 import RecentError from '@src/components/Home/RecentError/RecentError';
 
@@ -10,13 +10,10 @@ export async function getServerSideProps() {
 
   const stores = await homeAPI.getStores();
 
-  const errors = await homeAPI.getRecentErrors();
-
   return {
     props: {
       serving: serving,
       stores: stores,
-      errors: errors,
     },
   };
 }
@@ -24,18 +21,15 @@ export async function getServerSideProps() {
 interface IProps {
   serving: IServing;
   stores: IResponse;
-  errors: IRecentErrors;
 }
 
-const Home = ({ serving, stores, errors }: IProps) => {
-  console.log(errors);
-
+const Home = ({ serving, stores }: IProps) => {
   return (
     <StHome>
       <StBody>
         <Statistics serving={serving.all} />
         <StoreList stores={stores.stores} />
-        <RecentError errors={errors.error_notice} />
+        <RecentError />
       </StBody>
     </StHome>
   );

--- a/pages/robot/index.tsx
+++ b/pages/robot/index.tsx
@@ -1,11 +1,209 @@
-import { motion } from 'framer-motion';
+import styled from '@emotion/styled';
+import homeAPI from '@src/api/home';
+import robotAPI from '@src/api/robot';
+import DropDown from '@src/components/Common/DropDown';
+import Spinner from '@src/components/Common/Spinner';
+import Title from '@src/components/Common/Title';
+import RobotCard from '@src/components/Robot/RobotCard';
+import useInfiniteScroll from '@src/hooks/useInfiniteScroll';
+import { IRobotState, IRobotStateObj, IRobotType, IStoreNameObj } from '@src/types/robot';
+import { useRef, useState } from 'react';
 
-const Robot = () => {
+export async function getServerSideProps() {
+  const stores = await homeAPI.getStores();
+
+  const robots: any = await robotAPI.getRobots();
+
+  const changeStoreName = (storeName: string) => {
+    const storeNameObj: IStoreNameObj = {
+      '노리배달쿡 항동점': '항동 노리 배달쿡',
+      '더피플버거 연신내점': '연신내 더피플버거',
+      '배달쿡공유주방 오산점': '오산 공유주방',
+      차세대융합인증원: '차세대 융합 기술 연구원',
+      신도림: '더티프라이',
+      노원_발란: '노원 발란',
+    };
+
+    return storeNameObj[storeName];
+  };
+
+  const changeRobotState = (robotState: string) => {
+    const robotStateObj: IRobotStateObj = {
+      '1': '에러',
+      '2': '이동중',
+      '3': '대기중',
+      '4': '충전중',
+      '5': '수리중',
+      '6': '정보없음',
+    };
+
+    return robotStateObj[robotState];
+  };
+
+  const organizedRobots = robots.robot.map((robot: IRobotState) => ({
+    ...robot,
+    k_map_name: changeStoreName(robot.k_map_name),
+    robot_state: changeRobotState(robot.robot_state),
+  }));
+
+  return {
+    props: {
+      stores: stores,
+      robots: organizedRobots,
+    },
+  };
+}
+
+interface IProps {
+  stores: IResponse;
+  robots: IRobotState[];
+}
+
+const Robot = ({ robots, stores }: IProps) => {
+  const [robotList, setRobotList] = useState<IRobotState[]>(robots);
+
+  const [storeName, setStoreName] = useState<string>('전체매장');
+
+  const [robotState, setRobotState] = useState<string>('전체로봇');
+
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading } = useInfiniteScroll(robotList, observerRef);
+
+  const storeNameList: IDropDownList[] = [
+    { id: '0', option: '전체매장' },
+    ...stores.stores.map(({ map_name, map_id }) => ({
+      id: map_id,
+      option: map_name,
+    })),
+  ];
+
+  const copiedRobotList = [...robots];
+
+  const createRobotType = (id: string, option: string, color?: string) => {
+    return {
+      id,
+      option,
+      color,
+    };
+  };
+
+  const ROBOT_TYPE: IRobotType[] = [
+    createRobotType('0', '전체로봇'),
+    createRobotType('1', '에러', '#DA376E'),
+    createRobotType('2', '이동중', '#299D38'),
+    createRobotType('3', '대기중', '#D9AC37'),
+    createRobotType('4', '충전중', '#D9AC37'),
+    createRobotType('5', '수리중', '#406DFA'),
+    createRobotType('6', '정보없음'),
+  ];
+
+  const storeNameHandler = (storeName: string) => {
+    setStoreName(storeName);
+  };
+
+  const robotStateHandler = (robotState: string) => {
+    setRobotState(robotState);
+  };
+
+  const robotListHandler = (robotList: IRobotState[]) => {
+    setRobotList(robotList);
+  };
+
+  const filterByStoreName = (option: string) => {
+    storeNameHandler(option);
+
+    robotStateHandler('전체로봇');
+
+    if (option === '전체매장') return robotListHandler(copiedRobotList);
+
+    robotListHandler(copiedRobotList.filter((robot) => robot.k_map_name === option));
+  };
+
+  const filterByRobotState = (option: string) => {
+    robotStateHandler(option);
+
+    if (storeName !== '전체매장' && option === '전체로봇')
+      return robotListHandler(copiedRobotList.filter((robot) => robot.k_map_name === storeName));
+
+    storeName === '전체매장'
+      ? robotListHandler(copiedRobotList.filter((robot) => robot.robot_state === option))
+      : robotListHandler(
+          copiedRobotList.filter((robot) => robot.k_map_name === storeName && robot.robot_state === option),
+        );
+  };
+
   return (
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-      로봇페이지
-    </motion.div>
+    <StRobot>
+      <StHeader>
+        <Title title="로봇 현황" />
+        <StDropDownBox>
+          <DropDown selected={storeName} list={storeNameList} event={filterByStoreName} />
+          <DropDown selected={robotState} list={ROBOT_TYPE} event={filterByRobotState} />
+        </StDropDownBox>
+      </StHeader>
+      <StBody>
+        {data.length !== 0 ? (
+          data.map((cur: IRobotState, idx: number) => <RobotCard key={idx} {...cur} ROBOT_TYPE={ROBOT_TYPE} />)
+        ) : (
+          <StNull>해당 조건에 맞는 로봇이 존재하지 않습니다</StNull>
+        )}
+        {isLoading && (
+          <StSpinnerBox>
+            <Spinner />
+          </StSpinnerBox>
+        )}
+        <div ref={observerRef} />
+      </StBody>
+    </StRobot>
   );
 };
+
+const StRobot = styled.div`
+  padding: 10vh 20px;
+  width: 100%;
+  background: ${({ theme }) => theme.color.background};
+`;
+
+const StHeader = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+  width: 100%;
+`;
+
+const StDropDownBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+`;
+
+const StBody = styled.main`
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+`;
+
+const StNull = styled.p`
+  width: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50%;
+  color: ${({ theme }) => theme.color.gray500};
+  font-size: 20px;
+  text-align: center;
+`;
+
+const StSpinnerBox = styled.div`
+  position: relative;
+  width: 100%;
+`;
 
 export default Robot;

--- a/pages/store/index.tsx
+++ b/pages/store/index.tsx
@@ -40,9 +40,9 @@ const Store = ({ stores }: IProps) => {
     option: storeName,
   }));
 
-  const pageHandler = (storeId: string, storeName: string) => {
-    setStoreName(storeName);
-    router.push(`/store/${storeId}`);
+  const pageHandler = (option: string, id: string) => {
+    setStoreName(option);
+    router.push(`/store/${id}`);
   };
 
   return (
@@ -54,7 +54,7 @@ const Store = ({ stores }: IProps) => {
       <StBody>
         <KakaoMap stores={stores.stores} />
         {stores.stores.map(({ map_id: storeId, map_name: storeName, descirbe, img_src }) => (
-          <StStoreInfo key={storeId} onClick={() => pageHandler(storeId, storeName)}>
+          <StStoreInfo key={storeId} onClick={() => pageHandler(storeName, storeId)}>
             <StInfoBox>
               <StFlexBox>
                 <Image src={img_src} width={75} height={50} alt="매장 로고" />

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -4,7 +4,6 @@ const API = {
   getRecentErrors: '/api/monitoring-system/error-notice/all',
   postDates: '/api/monitoring-system/error-notice/by-time',
   getRobots: '/api/monitoring-system/robot?state=',
-  getRobotsDetail: '/api/monitoring-system/robot/map_id',
   getErrorList: '/api/monitoring-system/error-statistic',
   postErrorDates: '/api/monitoring-system/error-statistic',
   postErrorDetail: '/api/monitoring-system/error-detail',

--- a/src/api/robot.ts
+++ b/src/api/robot.ts
@@ -5,9 +5,6 @@ const robotAPI = {
   getRobots: () => {
     return client.get(`${API.getRobots}`);
   },
-  getRobotsDetail: (mapId: string) => {
-    return client.get(`${API.getRobotsDetail}/${mapId}?state=`);
-  },
 };
 
 export default robotAPI;

--- a/src/components/Common/DropDown.tsx
+++ b/src/components/Common/DropDown.tsx
@@ -21,14 +21,21 @@ const DropDown = ({ selected, list, event }: IProps) => {
     setisOpen(false);
   });
 
+  const filteredList = list.filter((cur) => cur.option !== selected);
+
   return (
     <StDropdown ref={ref}>
       <StSelected isOpen={isOpen} onClick={dropdownHandler}>
         {selected}
       </StSelected>
       <StSelect isOpen={isOpen}>
-        {list.map(({ id, option }: IDropDownList) => (
-          <StOption key={id} onClick={() => event(id, option)}>
+        {filteredList.map(({ id, option }: IDropDownList) => (
+          <StOption
+            key={id}
+            onClick={() => {
+              event(option, id);
+              setisOpen(false);
+            }}>
             {option}
           </StOption>
         ))}
@@ -53,7 +60,7 @@ const StSelected = styled.button<{ isOpen: boolean }>`
   border-bottom-left-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
   border-bottom-right-radius: ${({ isOpen }) => (isOpen ? '0px' : '5px')};
   font-size: 11px;
-  z-index: 2;
+  z-index: 20;
   cursor: pointer;
 
   :hover {
@@ -74,7 +81,7 @@ const StSelect = styled.div<{ isOpen: boolean }>`
   translate: ${({ isOpen }) => (isOpen ? '0' : '0 -30px')};
   transition: 0.4s;
   overflow: hidden;
-  z-index: 1;
+  z-index: 20;
 `;
 
 const StOption = styled.button`
@@ -87,6 +94,7 @@ const StOption = styled.button`
   border-bottom: ${({ theme }) => `0.1px solid ${theme.color.white}`};
   cursor: pointer;
   font-size: 10px;
+  z-index: 20;
 
   :hover {
     background: ${({ theme }) => theme.color.main};

--- a/src/components/Common/TopNav.tsx
+++ b/src/components/Common/TopNav.tsx
@@ -26,7 +26,7 @@ const StTopNav = styled.nav`
   height: 8vh;
   background: white;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
-  z-index: 10;
+  z-index: 100;
 `;
 
 const StHeader = styled.header`

--- a/src/components/Robot/RobotCard.tsx
+++ b/src/components/Robot/RobotCard.tsx
@@ -8,16 +8,22 @@ interface IProps {
   state: string;
   battery: string;
   serial_number: string;
+  robot_state: string;
   ROBOT_TYPE: IRobotType[];
 }
 
-const RobotCard = ({ k_map_name, serving_count, distance, state, battery, serial_number, ROBOT_TYPE }: IProps) => {
+const RobotCard = ({
+  k_map_name,
+  serving_count,
+  distance,
+  state,
+  battery,
+  serial_number,
+  ROBOT_TYPE,
+  robot_state,
+}: IProps) => {
   const getColorById = (id: string) => {
     return ROBOT_TYPE.filter((robot) => robot.id === id)[0].color;
-  };
-
-  const getStateById = (id: string) => {
-    return ROBOT_TYPE.filter((robot) => robot.id === id)[0].state;
   };
 
   return (
@@ -25,7 +31,7 @@ const RobotCard = ({ k_map_name, serving_count, distance, state, battery, serial
       <StHeader>
         <StStore>{k_map_name}</StStore>
         <StGapBox>
-          <StState color={getColorById(state)}>{getStateById(state)}</StState>
+          <StState color={getColorById(state)}>{robot_state}</StState>
           <StImg src={`/assets/icons/robot/robot_state_${state}.png`} alt="로봇이미지" />
         </StGapBox>
       </StHeader>
@@ -44,7 +50,7 @@ const RobotCard = ({ k_map_name, serving_count, distance, state, battery, serial
         <StBatteryBox>
           <StBatteryBar width={Number(battery) > 0 ? Number(battery) : 0} />
         </StBatteryBox>
-        <StBatteryPercent>{battery}%</StBatteryPercent>
+        <StBatteryPercent>{Math.sign(Number(battery)) === -1 ? 0 : battery}%</StBatteryPercent>
       </StFooter>
     </StRobotCard>
   );

--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -1,18 +1,18 @@
 import { RefObject, useEffect, useState } from 'react';
 
-const useInfiniteScroll = (initialData: IErrorNotice[], ref: RefObject<HTMLDivElement>) => {
+const useInfiniteScroll = (initialData: any, ref: RefObject<HTMLDivElement>) => {
   const [isLoading, setisLoading] = useState<boolean>(false);
-  const [data, setData] = useState<IErrorNotice[]>([]);
+  const [data, setData] = useState([]);
 
   useEffect(() => {
-    setData(initialData.slice(0, 20));
+    setData(initialData.slice(0, 10));
   }, [initialData]);
 
   const loadMoreData = () => {
     setisLoading(true);
 
     setTimeout(() => {
-      const updatedData = initialData.slice(0, data.length + 20);
+      const updatedData = initialData.slice(0, data.length + 15);
       setData(updatedData);
       setisLoading(false);
     }, 500);

--- a/src/types/robot.ts
+++ b/src/types/robot.ts
@@ -23,10 +23,14 @@ export type IRobotState = {
 
 export type IRobotType = {
   id: string;
-  state: string;
-  color: string;
+  option: string;
+  color: string | undefined;
 };
 
 export type IStoreNameObj = {
+  [index: string]: string;
+};
+
+export type IRobotStateObj = {
   [index: string]: string;
 };


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Robot 페이지 내에서 dropdown을 통한 로봇 카드 이중 필터링

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 데이터 가공
- 현재 서버에서 보내주는 데이터를 클라이언트에서 바로 사용하기에는 부적합하기 때문에 이를 위해 changeStoreName과 changeRobotState 함수를 사용하여 상점 이름과 로봇 상태를 가공.
- 서버에서 내려주는 robot 데이터의 k_map_name의 경우 다른 곳에서는 '항동 노리 배달쿡'으로 전달해주지만 robot api에서는 '노리 배달쿡 항동점' 과 같이 이름이 변형되어 전달.
- 이를 다른 곳과 통일성있게 맞춰주기 위해 storeNameObj라는 객체를 다음과 같은 구조로 생성 {서버에서 내려주는 데이터  명: 바꾸고 싶은 데이터 명}
- 객체 매핑을 통해 데이터 가공 진행. robotState도 마찬가지로 진행

2. DropDown을 통한 robot card 이중 필터링
- filterByStoreName, filterByRobotState 이라는 함수를 사용하여 DropDown에서 선택한 option에 따라 robot card가 필터링.
- 매장 이름, 로봇 상태에 따라 올바른 필터링이 가능하게끔 나오도록 조건문 추가.

3.  웹 페이지의 부하를 줄이기 위해 useInfiniteScroll 커스텀 훅을 사용하여 무한 스크롤을 구현
- 데이터를 불러올 동안 유저에게 가시적으로 보여줄 Spinner 추가