### PR TITLE
ADD : ErrorDetail 레이아웃 구현

### DIFF
--- a/pages/error/[errorId].tsx
+++ b/pages/error/[errorId].tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useMutation } from 'react-query';
+import { ParsedUrlQuery } from 'querystring';
+import { AxiosError } from 'axios';
+import { IErrorDetail, IErrorState } from '@src/types/error';
+import errorAPI from '@src/api/error';
+import ErrorInfo from '@src/components/Error/ErrorInfo';
+import ServingErrorCount from '@src/components/Error/ServingErrorCount';
+import SolutionList from '@src/components/Error/SolutionList';
+import RelatedErrors from '@src/components/Error/RelatedErrors';
+import styled from '@emotion/styled';
+
+const ErrorDetail = () => {
+  const router = useRouter();
+
+  const requestData = router.query as ParsedUrlQuery & IErrorState;
+
+  const {
+    mutate: postErrorState,
+    data,
+    isLoading,
+  } = useMutation<IErrorDetail, AxiosError, IErrorState>('errorDetail', (data: IErrorState) =>
+    errorAPI.getErrorDetail(data),
+  );
+
+  useEffect(() => {
+    if (Object.keys(requestData).length !== 0) {
+      return postErrorState(requestData);
+    }
+  }, [requestData]);
+
+  const errorContent = data && data.error_content;
+  const errorCount = data && data.error_count;
+  const errorInfo = data && data.error_info;
+  const errorList = data && data.error_list;
+  const errorSolveList = data && data.error_solve_list;
+
+  return (
+    <StErrorDetail>
+      <StBody>
+        <ErrorInfo />
+        <ServingErrorCount />
+        <RelatedErrors />
+        <SolutionList />
+      </StBody>
+    </StErrorDetail>
+  );
+};
+
+const StErrorDetail = styled.div`
+  width: 100%;
+`;
+
+const StHeader = styled.header`
+  width: 100%;
+`;
+
+const StBody = styled.main`
+  width: 100%;
+`;
+
+const StFooter = styled.footer`
+  width: 100%;
+`;
+
+export default ErrorDetail;

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -6,7 +6,7 @@ const API = {
   getRobots: '/api/monitoring-system/robot?state=',
   getErrorList: '/api/monitoring-system/error-statistic',
   postErrorDates: '/api/monitoring-system/error-statistic',
-  postErrorDetail: '/api/monitoring-system/error-detail',
+  getErrorDetail: '/api/monitoring-system/error-detail',
 };
 
 export default API;

--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -1,6 +1,6 @@
 import client from './client';
 import API from './apis';
-import { IDates } from '@src/types/error';
+import { IDates, IErrorState } from '@src/types/error';
 
 const errorAPI = {
   getErrorList: () => {
@@ -9,8 +9,8 @@ const errorAPI = {
   postErrorDates: (data: IDates) => {
     return client.post(`${API.postErrorDates}`, data);
   },
-  postErrorDetail: (data: any) => {
-    return client.post(`${API.postErrorDetail}`, data);
+  getErrorDetail: (data: IErrorState) => {
+    return client.post(`${API.getErrorDetail}`, data);
   },
 };
 

--- a/src/components/Common/Error.tsx
+++ b/src/components/Common/Error.tsx
@@ -1,11 +1,32 @@
 import styled from '@emotion/styled';
 import { IErrorState } from '@src/types/error';
+import { useRouter } from 'next/router';
 import { MdArrowForwardIos } from 'react-icons/md';
 
-const Error = ({ error_msg, created_at, k_map_name, risk_degree, error_id, error_type }: IErrorState) => {
+const Error = ({
+  error_msg,
+  created_at,
+  k_map_name,
+  risk_degree,
+  error_id,
+  error_type,
+  map_id,
+  robot_id,
+}: IErrorState) => {
+  const router = useRouter();
+
+  const requestData = { created_at, error_id, error_type, map_id, robot_id };
+
+  const pageHandler = () => {
+    router.push({
+      pathname: `/error/${error_id}`,
+      query: requestData,
+    });
+  };
+
   return (
-    <StError>
-      <StHeader color={risk_degree}></StHeader>
+    <StError onClick={pageHandler}>
+      <StHeader color={risk_degree} />
       <StBody>
         <StErrorMessage>{error_msg ? error_msg.split(',').join(', ') : '확인되지 않은 에러입니다.'}</StErrorMessage>
         <StFlexBox>

--- a/src/components/Error/ErrorInfo.tsx
+++ b/src/components/Error/ErrorInfo.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ErrorInfo = () => {
+  return <div></div>;
+};
+
+export default ErrorInfo;

--- a/src/components/Error/RelatedErrors.tsx
+++ b/src/components/Error/RelatedErrors.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const RelatedErrors = () => {
+  return <div></div>;
+};
+
+export default RelatedErrors;

--- a/src/components/Error/ServingErrorCount.tsx
+++ b/src/components/Error/ServingErrorCount.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ServingErrorCount = () => {
+  return <div></div>;
+};
+
+export default ServingErrorCount;

--- a/src/components/Error/SolutionList.tsx
+++ b/src/components/Error/SolutionList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SolutionList = () => {
+  return <div></div>;
+};
+
+export default SolutionList;

--- a/src/components/Home/RecentError/RecentError.tsx
+++ b/src/components/Home/RecentError/RecentError.tsx
@@ -74,8 +74,6 @@ const RecentError = () => {
     },
   );
 
-  console.log(refetchTime());
-
   return (
     <StRecentError>
       <StHeader>

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -21,3 +21,30 @@ export type IErrorState = {
   k_map_name: string;
   risk_degree: string;
 };
+
+export type IErrorDetail = {
+  error_content: IErrorContent;
+  error_count: IErrorCount;
+  error_info: IErrorInfo;
+  error_list: IErrorState[];
+  error_solve_list: IErrorState[];
+};
+
+export type IErrorContent = {
+  content: string;
+  manager: string;
+};
+
+export type IErrorCount = {
+  month_error_count: string;
+  month_serving_count: string;
+  week_error_count: string;
+  week_serving_count: string;
+};
+
+export type IErrorInfo = {
+  battery: string;
+  map_existence: string;
+  recent_table: string;
+  robot_path: string;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 홈, 에러 페이지에서 에러 클릭 시 detail 페이지로 이동
- 백엔드의 요청으로 에러의 발생시간, 타입, 아이디, 로봇 아이디, 매장 아이디를 post로 요청 후 받은 데이터를 detail 페이지에서 렌더링 할 수 있도록 데이터 패칭 구현  

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 페이지 이동시 데이터 전달
- 일반적으로 detail 페이지의 경우 해당 데이터의 아이디 값을 넣어 get요청을 보내는 등 pathparameter 형식으로 구현하는 것이 일반적이나, 백엔드의 요청으로  에러의 발생시간, 타입, 아이디, 로봇 아이디, 매장 아이디를 post로 요청후 필요한 데이터를 받는 형식으로 구현.
- 이를 구현하기 위해 페이지 이동 시 useRouter의 query에 해당 데이터를 넣어 페이지에 넘겨주는 형식으로 구현
```
  const pageHandler = () => {
    router.push({
      pathname: `/error/${error_id}`,
      query: requestData,
    });
  };
```
- 이동된 페이지에서 해당 데이터를 useEffect와 useMutation을 이용해 데이터 패칭
- 처음 페이지 진입 시 서버에게 전달할 데이터(페이지 이동시 넘겨준 데이터)가 처음에는 빈 객체로 할당되었다가 나중에 데이터가 추가되는 플로우 때문에 서버에 빈객체가 전달되어 에러가 발생
- 이를 해결하기 위해 객체를 배열로 바꾼 후 length가 0이 아닐 때(빈 객체가 아닐 때) 데이터를 패칭할 수 있도록 추가적인 조건문 추가
```
  useEffect(() => {
    if (Object.keys(requestData).length !== 0) {
      return postErrorState(requestData);
    }
  }, [requestData]);
``` 