### PR TITLE
ADD : Count 컴포넌트 구현

### DIFF
--- a/pages/error/[errorId].tsx
+++ b/pages/error/[errorId].tsx
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 import { IErrorDetail, IErrorState } from '@src/types/error';
 import errorAPI from '@src/api/error';
 import ErrorInfo from '@src/components/Error/ErrorInfo';
-import ServingErrorCount from '@src/components/Error/ServingErrorCount';
+import Count from '@src/components/Error/Count';
 import SolutionList from '@src/components/Error/SolutionList';
 import RelatedErrors from '@src/components/Error/RelatedErrors';
 import styled from '@emotion/styled';
@@ -37,7 +37,16 @@ const ErrorDetail = () => {
     <StErrorDetail>
       <StBody>
         <ErrorInfo errorInfo={errorInfo} />
-        <ServingErrorCount />
+        <Count
+          type="error"
+          week={errorCount && errorCount.week_error_count}
+          month={errorCount && errorCount.month_error_count}
+        />
+        <Count
+          type="serving"
+          week={errorCount && errorCount.week_serving_count}
+          month={errorCount && errorCount.month_serving_count}
+        />
         <RelatedErrors />
         <SolutionList />
       </StBody>

--- a/src/components/Error/Count.tsx
+++ b/src/components/Error/Count.tsx
@@ -1,0 +1,99 @@
+import Title from '../Common/Title';
+import { IConstantData } from '@src/types/error';
+import styled from '@emotion/styled';
+
+interface IProps {
+  type: string;
+  week?: string;
+  month?: string;
+}
+
+const Count = ({ type, week, month }: IProps) => {
+  if (!week || !month) {
+    return null;
+  }
+
+  const createCountInfo = (id: number, title: string, description: string) => {
+    return { id, title, description };
+  };
+
+  const COUNT_INFO: IConstantData[] = [createCountInfo(0, '일주일', week), createCountInfo(1, '한 달', month)];
+
+  return (
+    <StCount>
+      <StHeader>
+        <Title title={type === 'error' ? '에러 정보' : '서빙 정보'} />
+      </StHeader>
+      <StBody>
+        <StSubTitle>{type === 'error' ? '최근 에러 횟수' : '최근 서빙 횟수'}</StSubTitle>
+        <StDevider />
+        <StFlexBox>
+          {COUNT_INFO.map(({ id, title, description }) => (
+            <StCountBox key={id}>
+              <StDescription>{description}</StDescription>
+              <StPeriod>{title}</StPeriod>
+            </StCountBox>
+          ))}
+        </StFlexBox>
+      </StBody>
+    </StCount>
+  );
+};
+
+const StCount = styled.div`
+  margin-top: 30px;
+  width: 100%;
+`;
+
+const StHeader = styled.header`
+  width: 100%;
+`;
+
+const StBody = styled.main`
+  padding: 20px;
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  background: ${({ theme }) => theme.color.white};
+  border-radius: 5px;
+`;
+
+const StDevider = styled.hr`
+  margin: 1vw 0;
+  width: 100%;
+  border: ${({ theme }) => `0.5px solid ${theme.color.gray400}`};
+`;
+
+const StPeriod = styled.p`
+  margin-top: 5px;
+  color: ${({ theme }) => theme.color.gray700};
+`;
+
+const StDescription = styled.p`
+  color: ${({ theme }) => theme.color.main};
+  font-weight: 600;
+`;
+
+const StSubTitle = styled.p`
+  color: ${({ theme }) => theme.color.gray700};
+`;
+
+const StFlexBox = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 100px;
+`;
+
+const StCountBox = styled.div`
+  width: fit-content;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export default Count;

--- a/src/components/Error/ErrorInfo.tsx
+++ b/src/components/Error/ErrorInfo.tsx
@@ -1,5 +1,5 @@
 import Title from '../Common/Title';
-import { IConstantErrorInfo, IErrorInfo } from '@src/types/error';
+import { IConstantData, IErrorInfo } from '@src/types/error';
 import { IStoreNameObj } from '@src/types/robot';
 import styled from '@emotion/styled';
 
@@ -15,25 +15,12 @@ const ErrorInfo = ({ errorInfo }: IProps) => {
   const finalTarget: string = errorInfo && errorInfo.robot_path.split(',')[0].split('!').join(' , ');
   const organizedPath = errorInfo && errorInfo.robot_path.split(',').join(' , ');
 
-  const convertStoreName = (storeId: string) => {
-    const storeObj: IStoreNameObj = {
-      '1': '항동 노리 배달쿡',
-      '2': '연신내 더피플버거',
-      '3': '오산 공유주방',
-      '4': '차세대 융합 기술 연구원',
-      '5': '더티 프라이',
-      '6': '노원 발란',
-    };
-
-    return storeObj[storeId];
-  };
-
   const createErrorInfo = (id: number, title: string, description: string) => {
     return { id, title, description };
   };
 
-  const ERROR_INFO: IConstantErrorInfo[] = [
-    createErrorInfo(0, '발생한 매장', convertStoreName(errorInfo && errorInfo.map_existence)),
+  const ERROR_INFO: IConstantData[] = [
+    createErrorInfo(0, '에러가 발생한 Map Node', errorInfo && errorInfo.map_existence),
     createErrorInfo(1, '최근 목적지', errorInfo && errorInfo.recent_table + '번 테이블'),
     createErrorInfo(2, '현재 배터리', errorInfo && errorInfo.battery + '%'),
     createErrorInfo(3, '최근 Final Traget', finalTarget),

--- a/src/components/Error/ErrorList.tsx
+++ b/src/components/Error/ErrorList.tsx
@@ -15,8 +15,6 @@ const ErrorList = ({ errorList }: IProps) => {
 
   const { data, isLoading } = useInfiniteScroll(errorList, observerRef);
 
-  console.log(data);
-
   return (
     <StErrorList>
       <StHeader>

--- a/src/components/Error/ServingErrorCount.tsx
+++ b/src/components/Error/ServingErrorCount.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const ServingErrorCount = () => {
-  return <div></div>;
-};
-
-export default ServingErrorCount;

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -49,7 +49,7 @@ export type IErrorInfo = {
   robot_path: string;
 };
 
-export type IConstantErrorInfo = {
+export type IConstantData = {
   id: number;
   title: string;
   description: string;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 에러페이지에서 에러 정보, 서빙 정보를 나타내는 Count 컴포넌트 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. type에 따른 분기처리
- 에러 정보, 서빙 정보 모두 같은 구조를 가지고 있기 때문에 하나의 컴포넌트 안에서 type에 따라 분기처리 진행.
- 부모 컴포넌트(Error 페이지)에서 type을 error 또는 serving을 내려주어 구분

2. 코드 가독성 향상 및 단축
- 코드의 중복을 줄이기 위해 상수데이터를 만들고 이를 map으로 처리