### PR TITLE
REFACT : Error Detail 페이지 리팩토링

### DIFF
--- a/src/components/Common/DetailNav.tsx
+++ b/src/components/Common/DetailNav.tsx
@@ -51,6 +51,7 @@ const StTitle = styled.p`
   transform: translate(-50%, -50%);
   color: ${({ theme }) => theme.color.gray700};
   font-size: 20px;
+  font-weight: 600;
 `;
 
 const StIcon = styled.div`
@@ -58,6 +59,7 @@ const StIcon = styled.div`
   top: 50%;
   left: 10%;
   transform: translate(-50%, -50%);
+  cursor: pointer;
 `;
 
 export default DetailNav;

--- a/src/components/Error/Count.tsx
+++ b/src/components/Error/Count.tsx
@@ -4,15 +4,11 @@ import styled from '@emotion/styled';
 
 interface IProps {
   type: string;
-  week?: string;
-  month?: string;
+  week: string;
+  month: string;
 }
 
 const Count = ({ type, week, month }: IProps) => {
-  if (!week || !month) {
-    return null;
-  }
-
   const createCountInfo = (id: number, title: string, description: string) => {
     return { id, title, description };
   };
@@ -22,11 +18,9 @@ const Count = ({ type, week, month }: IProps) => {
   return (
     <StCount>
       <StHeader>
-        <Title title={type === 'error' ? '에러 정보' : '서빙 정보'} />
+        <Title title={type === 'error' ? '최근 에러 횟수' : '최근 서빙 횟수'} />
       </StHeader>
       <StBody>
-        <StSubTitle>{type === 'error' ? '최근 에러 횟수' : '최근 서빙 횟수'}</StSubTitle>
-        <StDevider />
         <StFlexBox>
           {COUNT_INFO.map(({ id, title, description }) => (
             <StCountBox key={id}>
@@ -58,6 +52,7 @@ const StBody = styled.main`
   width: 100%;
   background: ${({ theme }) => theme.color.white};
   border-radius: 5px;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
 `;
 
 const StDevider = styled.hr`

--- a/src/components/Error/ErrorInfo.tsx
+++ b/src/components/Error/ErrorInfo.tsx
@@ -1,19 +1,13 @@
 import Title from '../Common/Title';
 import { IConstantData, IErrorInfo } from '@src/types/error';
-import { IStoreNameObj } from '@src/types/robot';
 import styled from '@emotion/styled';
 
 interface IProps {
-  errorInfo?: IErrorInfo;
+  errorInfo: IErrorInfo;
 }
 
 const ErrorInfo = ({ errorInfo }: IProps) => {
-  if (!errorInfo) {
-    return null;
-  }
-
   const finalTarget: string = errorInfo && errorInfo.robot_path.split(',')[0].split('!').join(' , ');
-  const organizedPath = errorInfo && errorInfo.robot_path.split(',').join(' , ');
 
   const createErrorInfo = (id: number, title: string, description: string) => {
     return { id, title, description };
@@ -24,7 +18,7 @@ const ErrorInfo = ({ errorInfo }: IProps) => {
     createErrorInfo(1, '최근 목적지', errorInfo && errorInfo.recent_table + '번 테이블'),
     createErrorInfo(2, '현재 배터리', errorInfo && errorInfo.battery + '%'),
     createErrorInfo(3, '최근 Final Traget', finalTarget),
-    createErrorInfo(4, '최근 경로', organizedPath),
+    createErrorInfo(4, '최근 경로', errorInfo && errorInfo.robot_path),
   ];
 
   return (
@@ -62,10 +56,12 @@ const StBody = styled.main`
   width: 100%;
   background: ${({ theme }) => theme.color.white};
   border-radius: 5px;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
 `;
 
 const StFlexBox = styled.div`
   width: 100%;
+  word-break: break-all;
 `;
 
 const StTitle = styled.span`

--- a/src/components/Error/RelatedErrors.tsx
+++ b/src/components/Error/RelatedErrors.tsx
@@ -1,14 +1,12 @@
-import styled from '@emotion/styled';
 import { IErrorState } from '@src/types/error';
-import React from 'react';
 import Title from '../Common/Title';
+import styled from '@emotion/styled';
 
 interface IProps {
   relatedErrors: IErrorState[];
 }
 
 const RelatedErrors = ({ relatedErrors }: IProps) => {
-  console.log(relatedErrors);
   return (
     <StRelatedErrors>
       <StHeader>
@@ -56,13 +54,14 @@ const StBody = styled.main`
   height: 300px;
   background: ${({ theme }) => theme.color.white};
   border-radius: 5px;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
   overflow: scroll;
 `;
 
 const StErrorBox = styled.div`
   padding: 10px;
   width: 100%;
-  background: ${({ theme }) => theme.color.white};
+  background: ${({ theme }) => theme.color.gray100};
   border: ${({ theme }) => `1px solid ${theme.color.gray400}`};
   border-radius: 5px;
   gap: 10px;

--- a/src/components/Error/SolutionList.tsx
+++ b/src/components/Error/SolutionList.tsx
@@ -1,5 +1,5 @@
 import Title from '../Common/Title';
-import { IConstantData, ISolution } from '@src/types/error';
+import { ISolution } from '@src/types/error';
 import styled from '@emotion/styled';
 
 interface IProps {
@@ -51,16 +51,17 @@ const StBody = styled.div`
   flex-direction: column;
   gap: 10px;
   width: 100%;
-  height: 300px;
+  max-height: 300px;
   background: ${({ theme }) => theme.color.white};
   border-radius: 5px;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
   overflow: scroll;
 `;
 
 const StSolution = styled.div`
   padding: 10px;
   width: 100%;
-  background: ${({ theme }) => theme.color.white};
+  background: ${({ theme }) => theme.color.gray100};
   border: ${({ theme }) => `1px solid ${theme.color.gray400}`};
   border-radius: 5px;
   gap: 10px;

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -27,7 +27,7 @@ export type IErrorDetail = {
   error_count: IErrorCount;
   error_info: IErrorInfo;
   error_list: IErrorState[];
-  error_solve_list: IErrorState[];
+  error_solve_list: ISolution[];
 };
 
 export type IErrorContent = {


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Error Detail 페이지 리팩토링

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. import 순서 변경
- 내장 => 외부 => 내부 => 스타일링 순으로 import 순서 변경

2. DetailNav 추가
- error detail 페이지 진입 시 header에 Nav를 추가하고 뒤로가기 기능을 구현

3. Count 컴포넌트 변경
- 비교적 한 눈에 보기 쉬운 UI를 위해 기존 SubTitle을 메인 Title로 바꾸는 작업 진행 

5. mutation 함수 수정
- errorAPI.getErrorDetail 함수는 getErrorDetail: (data: IErrorState) => Promise<AxiosResponse<any, any>> 형식을 갖기 때문에 mutationFn이 이 형식을 따르기 위해 수정
