### PR TITLE
ADD : Modal 컴포넌트 구현

### DIFF
--- a/src/components/Common/Modal.tsx
+++ b/src/components/Common/Modal.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+interface IProps {
+  text: string;
+  event: () => void;
+}
+
+const Modal = ({ text, event }: IProps) => {
+  const confirmHandler = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    event();
+  };
+
+  return (
+    <StModal>
+      <StContent>
+        <StBody>{text}</StBody>
+        <StFooter>
+          <StConfirmBtn onClick={confirmHandler}>확인</StConfirmBtn>
+        </StFooter>
+      </StContent>
+    </StModal>
+  );
+};
+
+const StModal = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+`;
+
+const StContent = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  width: 300px;
+  height: 120px;
+  border-radius: 10px;
+  background-color: white;
+`;
+
+const StBody = styled.main`
+  width: 100%;
+  height: 60%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StFooter = styled.footer`
+  margin: auto;
+  width: 90%;
+  height: 30%;
+`;
+
+const StConfirmBtn = styled.button`
+  width: 100%;
+  height: 100%;
+  border: none;
+  color: ${({ theme }) => theme.color.white};
+  background: ${({ theme }) => theme.color.stroke};
+  border-radius: 5px;
+`;
+
+export default Modal;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 유저에게 간단한 확인을 시켜주기 위한 공용 컴포넌트 Modal 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Modal 구현
- props로 modal에 들어갈 텍스트와 하단 버튼을 누르면 발생시킬 event를 부모 컴포넌트로부터 받아와 적용.
- modal은 isOpen이라는 useState로 관리하며, 적용시킨 페이지에서는 만약 검색할 매장을 선택하지 않는다면 modal이 열리고 매장을 선택해달라는 문구를 띄우는 형식으로 사용.
- modal이 열렸을 때 스크롤을 막기 위해 isOpen이 true일때 css를 이용해 스크롤을 금지.