### PR TITLE
ADD : 페이지 전환시 스피너 추가

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,11 +4,13 @@ import { useRouter } from 'next/router';
 import { Global, ThemeProvider } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
+import { useLoading } from '@src/hooks/useLoading';
 import global from 'styles/global';
 import theme from 'styles/theme';
 import Layout from '@src/components/Common/Layout';
 import TopNav from '@src/components/Common/TopNav';
 import BottomNav from '@src/components/Common/BottomNav';
+import Spinner from '@src/components/Common/Spinner';
 
 const App = ({ Component, pageProps }: AppProps) => {
   const { pathname } = useRouter();
@@ -17,11 +19,14 @@ const App = ({ Component, pageProps }: AppProps) => {
 
   const pageDepth = pathname.split('/').length;
 
+  const isLoading: boolean = useLoading();
+
   return (
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <ThemeProvider theme={theme}>
           <Layout>
+            {isLoading && <Spinner />}
             {pageDepth === 2 ? <TopNav /> : null}
             <Global styles={global} />
             <Component {...pageProps} />

--- a/pages/error/[errorId].tsx
+++ b/pages/error/[errorId].tsx
@@ -5,7 +5,6 @@ import { ParsedUrlQuery } from 'querystring';
 import { IErrorState } from '@src/types/error';
 import errorAPI from '@src/api/error';
 import DetailNav from '@src/components/Common/DetailNav';
-import Spinner from '@src/components/Common/Spinner';
 import ErrorInfo from '@src/components/Error/ErrorInfo';
 import Count from '@src/components/Error/Count';
 import SolutionList from '@src/components/Error/SolutionList';
@@ -22,11 +21,7 @@ const ErrorDetail = () => {
     return response;
   };
 
-  const {
-    mutate: postErrorState,
-    data: errorDetail,
-    isLoading,
-  } = useMutation(mutationFn, { mutationKey: 'errorDetail' });
+  const { mutate: postErrorState, data: errorDetail } = useMutation(mutationFn, { mutationKey: 'errorDetail' });
 
   useEffect(() => {
     if (Object.keys(requestData).length !== 0) {
@@ -38,8 +33,6 @@ const ErrorDetail = () => {
   const errorInfo = errorDetail && errorDetail.error_info;
   const relatedErrors = errorDetail && errorDetail.error_list;
   const solutionList = errorDetail && errorDetail.error_solve_list;
-
-  if (isLoading) return <Spinner />;
 
   return (
     <StErrorDetail>

--- a/src/hooks/useLoading.tsx
+++ b/src/hooks/useLoading.tsx
@@ -1,0 +1,32 @@
+import Router from 'next/router';
+import { useEffect, useState } from 'react';
+
+export const useLoading = () => {
+  const [isLoading, setisLoading] = useState<boolean>(false);
+
+  const start = () => {
+    setisLoading(true);
+  };
+
+  const end = () => {
+    setisLoading(false);
+  };
+
+  useEffect(() => {
+    Router.events.on('routeChangeStart', start);
+
+    Router.events.on('routeChangeComplete', end);
+
+    Router.events.on('routeChangeError', end);
+
+    return () => {
+      Router.events.off('routeChangeStart', start);
+
+      Router.events.off('routeChangeComplete', end);
+
+      Router.events.off('routeChangeError', end);
+    };
+  }, []);
+
+  return isLoading;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 페이지 전환시 스피너 추가

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 페이지 전환시 스피너 추가
- useLoading이라는 커스텀 훅을 제작.
```
const useLoading = () => {
  const [isLoading, setisLoading] = useState<boolean>(false);

  const start = () => {
    setisLoading(true);
  };

  const end = () => {
    setisLoading(false);
  };

  useEffect(() => {
    Router.events.on('routeChangeStart', start);

    Router.events.on('routeChangeComplete', end);

    Router.events.on('routeChangeError', end);

    return () => {
      Router.events.off('routeChangeStart', start);

      Router.events.off('routeChangeComplete', end);

      Router.events.off('routeChangeError', end);
    };
  }, []);

  return isLoading;
};
```
- isLoading이라는 상태 변수와 이를 변경하는 setisLoading 함수를 생성하고 초기값 false로 초기화. 이 변수는 로딩 중인지 여부를 나타냄.
- start 함수는 페이지 이동이 시작될 때 호출되며 isLoading 상태를 true로 설정하여 로딩 중임을 나타냄.
- end 함수는 페이지 이동이 완료되거나 에러가 발생했을 때 호출되며 isLoading 상태를 false로 설정하여 로딩이 끝났음을 나타냄.
- 페이지 이동이 시작되었을 때 start 함수를 호출하여 로딩 상태를 true로 설정하고 페이지 이동이 완료되었을 때 end 함수를 호출하여 로딩 상태를 false로 설정. 만약 페이지 이동 중 에러가 발생했을 때도 end 함수를 호출하여 로딩 상태를 false로 설정.
