### PR TITLE
ADD : Error Handling 기능 추가

### DIFF
--- a/pages/Error.tsx
+++ b/pages/Error.tsx
@@ -1,0 +1,65 @@
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
+import { ParsedUrlQuery } from 'querystring';
+
+const Error = () => {
+  const router = useRouter();
+
+  const pageHandler = () => {
+    router.push('/');
+  };
+
+  const { errorDescription, errorCode } = router.query as ParsedUrlQuery;
+
+  return (
+    <StError>
+      <StHeader>{errorDescription}</StHeader>
+      <StBody>Error Code {errorCode}</StBody>
+      <StFooter>
+        <StBack onClick={pageHandler}>홈으로 돌아가기</StBack>
+      </StFooter>
+    </StError>
+  );
+};
+
+const StError = styled.div`
+  width: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+const StHeader = styled.header`
+  width: 100%;
+  color: ${({ theme }) => theme.color.gray500};
+  font-size: 20px;
+  text-align: center;
+`;
+
+const StBody = styled.main`
+  margin: 50px 0;
+  width: 100%;
+  color: ${({ theme }) => theme.color.main};
+  font-size: 60px;
+  font-weight: 700;
+  text-align: center;
+`;
+
+const StFooter = styled.footer`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+const StBack = styled.button`
+  width: 300px;
+  height: 40px;
+  border: none;
+  border-radius: 5px;
+  color: ${({ theme }) => theme.color.white};
+  background: ${({ theme }) => theme.color.sub};
+  cursor: pointer;
+`;
+
+export default Error;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,6 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import { useRouter } from 'next/router';
+import axios, { AxiosResponse } from 'axios';
+import { IErrorCodeObject } from '@src/types/common';
 
 export const baseURL: string = process.env.NEXT_PUBLIC_BASE_URL as string;
 
@@ -8,25 +10,36 @@ const client = axios.create({
   headers: { 'Content-Type': 'application/json;charset=utf-8' },
 });
 
-client.interceptors.response.use(
-  (res: AxiosResponse) => {
-    try {
-      if (res.status === 200) {
-        return res.data;
-      }
-    } catch (e: any) {
-      return e.message;
-    }
-  },
-  (error: AxiosError<IResponseError>) => {
-    const err = error.response?.data.message;
-
-    if (err) {
-      window.alert(err);
+client.interceptors.response.use((res: AxiosResponse) => {
+  try {
+    if (res.status === 200) {
+      return res.data;
     }
 
-    return Promise.reject(error);
-  },
-);
+    if (res.status === 400) {
+      const router = useRouter();
+
+      const errorCode: string = res?.data.code;
+
+      const errorCodeObject: IErrorCodeObject = {
+        '-1': '서버 내부에서 오류가 발생했습니다.',
+        '-2': '필수 인자가 포함되지 않은 경우나 호출 인자값의 데이터 타입이 적절하지 않거나 허용된 범위를 벗어났습니다.',
+        '-3': '해당 API에 대한 요청 권한이 없습니다.',
+        '-4': '서비스 점검중입니다.',
+        '-5': '데이터가 존재하지 않습니다.',
+        '-101': '로봇에서 에러가 발생했습니다.',
+        '-102': '로봇이 작동할 수 없는 환경입니다.',
+      };
+
+      const moveToErrorPage = () => {
+        router.push({ pathname: '/error', query: { errorCode, errorDescription: errorCodeObject[errorCode] } });
+      };
+
+      return moveToErrorPage();
+    }
+  } catch (e: any) {
+    return e.message;
+  }
+});
 
 export default client;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -19,3 +19,7 @@ export type IStoreNameObj = {
 export type IRobotStateObj = {
   [index: string]: string;
 };
+
+export type IErrorCodeObject = {
+  [index: string]: string;
+};


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 오류 코드에 따라 유저에게 알맞은 에러 페이지를 보여주기 위해 error handling 작업 진행 

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Error Handling 기능 추가
- 백엔드에서 클라에 던져주는 상태코드는 200과 400 2가지.
<img width="839" alt="스크린샷 2023-09-01 오후 8 33 33" src="https://github.com/zinukk/Mobile_H_Management_System/assets/97172321/f8c7004d-0183-4360-8606-b85885ecdefd">
- 각각의 코드에 맞는 errorCodeObject를 생성하고 객체 매핑을 통해 코드에 따라 알맞은 설명이 나오도록 구현.
- status가 만약 400 이라면 해당 에러코드와 에러메세지를 담아 Error page로 이동할 수 있도록 기능 구현.

```
 if (res.status === 400) {
      const router = useRouter();

      const errorCode: string = res?.data.code;

      const errorCodeObject: IErrorCodeObject = {
        '-1': '서버 내부에서 오류가 발생했습니다.',
        '-2': '필수 인자가 포함되지 않은 경우나 호출 인자값의 데이터 타입이 적절하지 않거나 허용된 범위를 벗어났습니다.',
        '-3': '해당 API에 대한 요청 권한이 없습니다.',
        '-4': '서비스 점검중입니다.',
        '-5': '데이터가 존재하지 않습니다.',
        '-101': '로봇에서 에러가 발생했습니다.',
        '-102': '로봇이 작동할 수 없는 환경입니다.',
      };

      const moveToErrorPage = () => {
        router.push({ pathname: '/error', query: { errorCode, errorDescription: errorCodeObject[errorCode] } });
      };

      return moveToErrorPage();
    }
```
