### PR TITLE
Refact : Home 페이지 리팩토링 완료

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,16 +37,15 @@ interface IResponse {
   stores: IStore[];
 }
 
-interface IErrorNotice {
+interface TErrorNotice {
   created_at: string;
   error_id: string;
+  error_msg: string;
   format_date: string;
   k_map_name: string;
-  error_msg: string;
-  log_id: string;
   map_id: string;
-  map_name: string;
   risk_degree: string;
+  robot_id: string;
 }
 
 interface IErrorRisk {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,38 +1,39 @@
+import type { GetServerSideProps } from 'next';
 import dynamic from 'next/dynamic';
-import { IServing } from '@src/types/home';
+import { TPerformance } from '@src/types/home';
 import homeAPI from '@src/api/home';
-import Statistics from '@src/components/Home/Statistics/Statistics';
+import RobotPerformance from '@src/components/Home/RobotPerformance/RobotPerformance';
 import StoreList from '@src/components/Home/StoreList/StoreList';
 import Spinner from '@src/components/Common/Spinner';
 import styled from '@emotion/styled';
 
-export async function getServerSideProps() {
-  const serving = await homeAPI.getServing();
+interface IProps {
+  performance: TPerformance;
+  stores: IResponse;
+}
 
-  const stores = await homeAPI.getStores();
+export const getServerSideProps: GetServerSideProps<IProps> = async () => {
+  const { data: performance } = await homeAPI.getRobotPerformance();
+
+  const { data: stores } = await homeAPI.getStores();
 
   return {
     props: {
-      serving: serving,
-      stores: stores,
+      performance,
+      stores,
     },
   };
-}
-
-interface IProps {
-  serving: IServing;
-  stores: IResponse;
-}
+};
 
 const RecentError = dynamic(() => import('@src/components/Home/RecentError/RecentError'), {
   loading: () => <Spinner />,
 });
 
-const Home = ({ serving, stores }: IProps) => {
+const Home = ({ performance, stores }: IProps) => {
   return (
     <StHome>
       <StBody>
-        <Statistics serving={serving.all} />
+        <RobotPerformance performance={performance.all} />
         <StoreList stores={stores.stores} />
         <RecentError />
       </StBody>

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -1,5 +1,5 @@
 const API = {
-  getServing: '/api/monitoring-system/statistic',
+  getRobotPerformance: '/api/monitoring-system/statistic',
   getStores: '/api/monitoring-system/store',
   getRecentErrors: '/api/monitoring-system/error-notice/all',
   postDates: '/api/monitoring-system/error-notice/by-time',

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -9,16 +9,16 @@ const client = axios.create({
   headers: { 'Content-Type': 'application/json;charset=utf-8' },
 });
 
-client.interceptors.response.use((res: AxiosResponse) => {
+client.interceptors.response.use((response: AxiosResponse) => {
   try {
-    if (res.status === 200) {
-      return res.data;
+    if (response.status === 200) {
+      return response;
     }
 
-    if (res.status === 400) {
+    if (response.status === 400) {
       const router = useRouter();
 
-      const errorCode: string = res?.data.code;
+      const errorCode: string = response?.data.code;
 
       const errorCodeObject: IErrorCodeObject = {
         '-1': '서버 내부에서 오류가 발생했습니다.',

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -2,8 +2,8 @@ import client from './client';
 import API from './apis';
 
 const homeAPI = {
-  getServing: () => {
-    return client.get(`${API.getServing}`);
+  getRobotPerformance: () => {
+    return client.get(`${API.getRobotPerformance}`);
   },
   getStores: () => {
     return client.get(`${API.getStores}`);

--- a/src/components/Home/RecentError/RecentError.tsx
+++ b/src/components/Home/RecentError/RecentError.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { useQuery } from 'react-query';
 import { useRecoilState } from 'recoil';
-import { IRiskDegree, IRiskDegreeList, ITimeMap } from '@src/types/home';
+import { TRecentErrors, TRiskDegree, TRiskDegreeList, TTimeMap } from '@src/types/home';
 import { recentErrorsState } from '@src/store/recentErrors';
 import homeAPI from '@src/api/home';
 import Title from '@src/components/Common/Title';
@@ -12,12 +12,13 @@ import styled from '@emotion/styled';
 
 const RecentError = () => {
   const [recentErrors, setRecentErrors] = useRecoilState(recentErrorsState);
+
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const { data, isLoading: scrollLoading } = useInfiniteScroll(recentErrors, observerRef);
+  const { data: recentErrorList, isLoading: scrollLoading } = useInfiniteScroll(recentErrors, observerRef);
 
-  const riskDegree: IRiskDegree = data.reduce(
-    (acc: IRiskDegree, { risk_degree }) => {
+  const riskDegree: TRiskDegree = recentErrorList.reduce(
+    (acc: TRiskDegree, { risk_degree }) => {
       acc['all'] = acc['all'] + 1;
       acc[risk_degree] = acc[risk_degree] + 1;
       return acc;
@@ -25,7 +26,7 @@ const RecentError = () => {
     { all: 0, minor: 0, major: 0, critical: 0 },
   );
 
-  const riskDegreeList: IRiskDegreeList[] = Object.entries(riskDegree).map(([degree, count], id) => ({
+  const riskDegreeList: TRiskDegreeList[] = Object.entries(riskDegree).map(([degree, count], id) => ({
     id,
     degree,
     count,
@@ -33,13 +34,18 @@ const RecentError = () => {
 
   const refetchTime = () => {
     const present: number = new Date().getTime();
+
     const presentHour: number = new Date().getHours();
+
     const isNightTime: boolean = presentHour >= 2 && presentHour < 6;
+
     const firstErrorTime: number = new Date(recentErrors && recentErrors[0] && recentErrors[0].created_at).getTime();
+
     const secondErrorTime: number = new Date(recentErrors && recentErrors[1] && recentErrors[1].created_at).getTime();
+
     const gap: number = firstErrorTime - secondErrorTime;
 
-    const timeMap: ITimeMap = {
+    const timeMap: TTimeMap = {
       60000: 5000,
       300000: 10000,
       600000: 20000,
@@ -59,18 +65,18 @@ const RecentError = () => {
     return 30000;
   };
 
-  const { isLoading: fetchLoading } = useQuery(
+  const fetchedErrorList = useQuery(
     ['recentErrors'],
     async () => {
-      const data = homeAPI.getRecentErrors();
-      return data;
+      const { data: errorList } = await homeAPI.getRecentErrors();
+
+      return errorList;
     },
     {
-      onSuccess: (data: { error_notice: IErrorNotice[] }) => {
-        setRecentErrors(data.error_notice);
+      onSuccess: ({ error_notice }: TRecentErrors) => {
+        return setRecentErrors(error_notice);
       },
       refetchInterval: refetchTime(),
-      staleTime: 30000,
     },
   );
 
@@ -79,7 +85,7 @@ const RecentError = () => {
       <StHeader>
         <Title title="최근 에러" />
         <StDegreeBox>
-          {riskDegreeList.map(({ id, degree }) => (
+          {riskDegreeList.map(({ id, degree }: TRiskDegreeList) => (
             <StFlexBox key={id}>
               <StColor color={degree} />
               <StDegree>{degree[0].toUpperCase() + degree.slice(1)}</StDegree>
@@ -89,7 +95,7 @@ const RecentError = () => {
       </StHeader>
       <StBody>
         <RiskDegree riskDegreeList={riskDegreeList} />
-        <RecentErrorList data={data} isLoading={scrollLoading} observerRef={observerRef} />
+        <RecentErrorList data={recentErrorList} isLoading={scrollLoading} observerRef={observerRef} />
       </StBody>
     </StRecentError>
   );

--- a/src/components/Home/RobotPerformance/PerformanceInfo.tsx
+++ b/src/components/Home/RobotPerformance/PerformanceInfo.tsx
@@ -1,11 +1,12 @@
 import { RiArrowDownSFill, RiArrowUpSFill } from 'react-icons/ri';
+import { TPerformanceData, TPerformanceInfo } from '@src/types/home';
 import styled from '@emotion/styled';
 
 interface IProps {
-  data: IStatistics;
+  date: TPerformanceData;
 }
 
-const StatisticsInfo = ({ data }: IProps) => {
+const PerformanceInfo = ({ date }: IProps) => {
   const {
     serving_count,
     serving_count_before,
@@ -15,9 +16,15 @@ const StatisticsInfo = ({ data }: IProps) => {
     avg_serving_time_before,
     performance,
     performance_before,
-  } = data;
+  } = date;
 
-  const createStatisticsInfo = (id: number, title: string, unit: string, currentValue: string, prevValue: string) => {
+  const createPerformanceInfo = (
+    id: number,
+    title: string,
+    unit: string,
+    currentValue: string,
+    prevValue: string,
+  ): TPerformanceInfo => {
     return {
       id,
       title,
@@ -27,11 +34,11 @@ const StatisticsInfo = ({ data }: IProps) => {
     };
   };
 
-  const STATISTICS_INFO = [
-    createStatisticsInfo(1, '서빙횟수', '', serving_count, serving_count_before),
-    createStatisticsInfo(2, '이동거리', 'km', move_distance, move_distance_before),
-    createStatisticsInfo(3, '서빙평균시간', 'm', avg_serving_time, avg_serving_time_before),
-    createStatisticsInfo(4, '주행효율', '%', performance, performance_before),
+  const PERFORMANCE_INFO: TPerformanceInfo[] = [
+    createPerformanceInfo(1, '서빙횟수', '번', serving_count, serving_count_before),
+    createPerformanceInfo(2, '이동거리', 'km', move_distance, move_distance_before),
+    createPerformanceInfo(3, '서빙평균시간', 'm', avg_serving_time, avg_serving_time_before),
+    createPerformanceInfo(4, '주행효율', '', performance, performance_before),
   ];
 
   const calcComparedPrev = (cur: string, prev: string) => {
@@ -39,9 +46,9 @@ const StatisticsInfo = ({ data }: IProps) => {
   };
 
   return (
-    <StStatisticsInfo>
+    <StPerformanceInfo>
       <StBody>
-        {STATISTICS_INFO.map(({ id, title, unit, currentValue, prevValue }) => (
+        {PERFORMANCE_INFO.map(({ id, title, unit, currentValue, prevValue }) => (
           <StInfoBox key={id}>
             <StCurrentBox>
               <StCurrent>
@@ -57,11 +64,11 @@ const StatisticsInfo = ({ data }: IProps) => {
           </StInfoBox>
         ))}
       </StBody>
-    </StStatisticsInfo>
+    </StPerformanceInfo>
   );
 };
 
-const StStatisticsInfo = styled.div`
+const StPerformanceInfo = styled.div`
   width: 100%;
 `;
 
@@ -117,4 +124,4 @@ const StPercentage = styled.p`
   font-size: 14px;
 `;
 
-export default StatisticsInfo;
+export default PerformanceInfo;

--- a/src/components/Home/RobotPerformance/RobotPerformance.tsx
+++ b/src/components/Home/RobotPerformance/RobotPerformance.tsx
@@ -1,32 +1,32 @@
 import { useState } from 'react';
-import { IDateTab, IServingByDate } from '@src/types/home';
+import { TDateTab, TPerformanceByDate } from '@src/types/home';
 import Title from '@src/components/Common/Title';
-import StatisticsInfo from './StatisticsInfo';
+import PerformanceInfo from './PerformanceInfo';
 import styled from '@emotion/styled';
 
 interface IProps {
-  serving: IServingByDate;
+  performance: TPerformanceByDate;
 }
 
-const Statistics = ({ serving }: IProps) => {
+const RobotPerformance = ({ performance }: IProps) => {
   const [tab, setTab] = useState<string>('일간');
 
-  const { day, week, month } = serving;
+  const { day, week, month } = performance;
 
   const tabHandler = (tab: string) => {
     setTab(tab);
   };
 
-  const DATE_TAB: IDateTab = {
-    일간: <StatisticsInfo data={day} />,
-    주간: <StatisticsInfo data={week} />,
-    월간: <StatisticsInfo data={month} />,
+  const DATE_TAB: TDateTab = {
+    일간: <PerformanceInfo date={day} />,
+    주간: <PerformanceInfo date={week} />,
+    월간: <PerformanceInfo date={month} />,
   };
 
   return (
-    <StStatistics>
+    <StRobotPerformance>
       <StHeader>
-        <Title title="통계 자료" />
+        <Title title="로봇 성능" />
         <StTabBox>
           {Object.keys(DATE_TAB).map((tabName, idx) => (
             <StTabBtn
@@ -41,11 +41,11 @@ const Statistics = ({ serving }: IProps) => {
         </StTabBox>
       </StHeader>
       <StBody>{DATE_TAB[tab]}</StBody>
-    </StStatistics>
+    </StRobotPerformance>
   );
 };
 
-const StStatistics = styled.div`
+const StRobotPerformance = styled.div`
   width: 100%;
 `;
 
@@ -82,4 +82,4 @@ const StBody = styled.div`
   width: 100%;
 `;
 
-export default Statistics;
+export default RobotPerformance;

--- a/src/components/Home/StoreList/Store.tsx
+++ b/src/components/Home/StoreList/Store.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import Image from 'next/image';
 import NoriImg from 'public/assets/images/store/nori-image.webp';
 import styled from '@emotion/styled';
+import { TStatistics, TStatus } from '@src/types/home';
 
 interface IProps {
   store: IStore;
@@ -10,40 +11,15 @@ interface IProps {
 const Store = ({ store }: IProps) => {
   const router = useRouter();
 
-  const { img_src, map_name, map_id, stay, refair, total, serving_count, error_count, performance } = store;
+  const { img_src, map_name, map_id, stay, refair, total, serving_count, error_count } = store;
 
-  const createStatus = (id: number, color: string, count: number) => {
-    return {
-      id,
-      color,
-      count,
-    };
-  };
+  const servingCount: number = parseInt(serving_count);
 
-  const STATUS = [
-    createStatus(0, 'main', parseInt(error_count)),
-    createStatus(1, 'sub', parseInt(serving_count)),
-    createStatus(2, 'stroke', parseInt(refair)),
-    createStatus(3, 'light', parseInt(stay)),
-  ];
+  const errorCount: number = parseInt(error_count);
 
-  const isValid = (data: null | string) => {
-    return data ? data : '측정불가';
-  };
+  const refairCount: number = parseInt(refair);
 
-  const createStatistics = (id: number, title: string, count: string) => {
-    return {
-      id,
-      title,
-      count,
-    };
-  };
-
-  const STATISTICS = [
-    createStatistics(0, '서빙횟수', isValid(serving_count)),
-    createStatistics(1, '에러횟수', isValid(error_count)),
-    createStatistics(2, '주행효율', isValid(performance)),
-  ];
+  const stayCount: number = parseInt(stay);
 
   const pageHandler = (storeId: string) => {
     router.push(`/store/${storeId}`);
@@ -53,7 +29,40 @@ const Store = ({ store }: IProps) => {
     return (count / total) * 100;
   };
 
-  console.log(map_id);
+  const performanceCalculator = (servingCount: number, errorCount: number) => {
+    if (servingCount === 0 && errorCount === 0) return 0;
+
+    return (servingCount / (servingCount + errorCount)).toFixed(2);
+  };
+
+  const createStatus = (id: number, color: string, count: number): TStatus => {
+    return {
+      id,
+      color,
+      count,
+    };
+  };
+
+  const STATUS: TStatus[] = [
+    createStatus(0, 'main', errorCount),
+    createStatus(1, 'sub', servingCount),
+    createStatus(2, 'stroke', refairCount),
+    createStatus(3, 'light', stayCount),
+  ];
+
+  const createStatistics = (id: number, title: string, count: string | number): TStatistics => {
+    return {
+      id,
+      title,
+      count,
+    };
+  };
+
+  const STATISTICS: TStatistics[] = [
+    createStatistics(0, '서빙횟수', servingCount),
+    createStatistics(1, '에러횟수', errorCount),
+    createStatistics(2, '주행효율', performanceCalculator(servingCount, errorCount)),
+  ];
 
   return (
     <StStore

--- a/src/components/Home/StoreList/StoreList.tsx
+++ b/src/components/Home/StoreList/StoreList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { IErrorStatus } from '@src/types/home';
+import { TRobotState } from '@src/types/home';
 import Title from '@src/components/Common/Title';
 import Store from './Store';
 import styled from '@emotion/styled';
@@ -11,9 +11,9 @@ interface IProps {
 const StoreList = ({ stores }: IProps) => {
   const [isOpen, setisOpen] = useState<boolean>(false);
 
-  const end = isOpen ? 6 : 3;
+  const end: number = isOpen ? 6 : 3;
 
-  const buttonText = isOpen ? '접기' : '더 보기 ';
+  const buttonText: string = isOpen ? '접기' : '더 보기 ';
 
   const organizedStores = stores.slice(0, end).map((store: IStore) => ({
     ...store,
@@ -24,19 +24,19 @@ const StoreList = ({ stores }: IProps) => {
     setisOpen(!isOpen);
   };
 
-  const createErrorStatus = (id: number, status: string, color: string) => {
+  const createRobotState = (id: number, state: string, color: string): TRobotState => {
     return {
       id,
-      status,
+      state,
       color,
     };
   };
 
-  const ERROR_STATUS: IErrorStatus[] = [
-    createErrorStatus(0, '에러', 'main'),
-    createErrorStatus(1, '서빙', 'sub'),
-    createErrorStatus(2, '대기', 'stroke'),
-    createErrorStatus(3, '수리', 'light'),
+  const ERROR_STATUS: TRobotState[] = [
+    createRobotState(0, '에러', 'main'),
+    createRobotState(1, '서빙', 'sub'),
+    createRobotState(2, '대기', 'stroke'),
+    createRobotState(3, '수리', 'light'),
   ];
 
   return (
@@ -44,10 +44,10 @@ const StoreList = ({ stores }: IProps) => {
       <StHeader>
         <Title title="전체 매장" />
         <StStatusBox>
-          {ERROR_STATUS.map(({ id, status, color }: IErrorStatus) => (
+          {ERROR_STATUS.map(({ id, state, color }: TRobotState) => (
             <StFlexBox key={id}>
-              <StColor status={status} color={color} />
-              <StStatus>{status}</StStatus>
+              <StColor status={state} color={color} />
+              <StStatus>{state}</StStatus>
             </StFlexBox>
           ))}
         </StStatusBox>

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -1,40 +1,51 @@
-export type IServing = {
-  1: IServingByDate;
-  2: IServingByDate;
-  3: IServingByDate;
-  4: IServingByDate;
-  901: IServingByDate;
-  908: IServingByDate;
-  909: IServingByDate;
-  910: IServingByDate;
-  914: IServingByDate;
-  all: IServingByDate;
+export type TPerformance = {
+  [key: string | number]: TPerformanceByDate;
 };
 
-export type IServingByDate = {
-  day: IStatistics;
-  week: IStatistics;
-  month: IStatistics;
+export type TPerformanceByDate = {
+  day: TPerformanceData;
+  week: TPerformanceData;
+  month: TPerformanceData;
 };
 
-export type IDateTab = {
+export type TPerformanceData = {
+  avg_serving_time: string;
+  avg_serving_time_before: string;
+  created_at: string;
+  day_type: string;
+  map_id: string;
+  map_name: string;
+  move_distance: string;
+  move_distance_before: string;
+  performance: string;
+  performance_before: string;
+  serving_count: string;
+  serving_count_before: string;
+};
+
+export type TDateTab = {
   [key: string]: JSX.Element;
-  일간: JSX.Element;
-  주간: JSX.Element;
-  월간: JSX.Element;
 };
 
-export type IRecentErrors = {
-  error_notice: IErrorNotice[];
+export type TPerformanceInfo = {
+  id: number;
+  title: string;
+  unit: string;
+  currentValue: string;
+  prevValue: string;
 };
 
-export type IRiskDegreeList = {
+export type TRecentErrors = {
+  error_notice: TErrorNotice[];
+};
+
+export type TRiskDegreeList = {
   id: number;
   degree: string;
   count: number;
 };
 
-export type IRiskDegree = {
+export type TRiskDegree = {
   [key: string]: number;
   all: number;
   minor: number;
@@ -42,19 +53,31 @@ export type IRiskDegree = {
   critical: number;
 };
 
-export type IErrorStatus = {
+export type TRobotState = {
   id: number;
-  status: string;
+  state: string;
   color: string;
 };
 
-export type IMap = {
+export type TStatistics = {
+  id: number;
+  title: string;
+  count: number | string;
+};
+
+export type TStatus = {
+  id: number;
+  color: string;
+  count: number;
+};
+
+export type TMap = {
   map_id: string;
   map_name: string;
   store_lat: string;
   store_lng: string;
 };
 
-export type ITimeMap = {
+export type TTimeMap = {
   [index: number]: number;
 };


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Home 페이지 리팩토링

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 해당 함수 및 변수가 어떤 기능을 하는 지 더욱 더 명확하고 쉽게 유추할 수 있도록 변경. 
- 컴포넌트가 어떤 기능을 하는 지 쉽게 유추할 수 있도록 변경.
- 해당 변수는 타입이라는 것을 더욱 명확히 알게 하기 위해 타입명의 첫 글자를 T로 시작하게끔 변경.
- API 호출명을 직관적으로 변경.

2. 상수데이터 타입 재지정
- 상수데이터를 생성할 때 오류를 방지하기 위해 타입을 추가적으로 명시.
- 변수명과 단위 정보를 객체로 캡슐화하고 상수명과 함수명을 카멜 케이스로 변경하여 TypeScript 관습을 따르도록 진행.

```
type PerformanceInfo = {
  id: number;
  title: string;
  unit: string;
  currentValue: string;
  prevValue: string;
};

const createPerformanceInfo = (
  id: number,
  title: string,
  unit: string,
  currentValue: string,
  prevValue: string
): PerformanceInfo => {
  return {
    id,
    title,
    unit,
    currentValue,
    prevValue,
  };
};

const performanceInfoData: PerformanceInfo[] = [
  createPerformanceInfo(1, '서빙 횟수', '', servingCount, servingCountBefore),
  createPerformanceInfo(2, '이동 거리', 'km', moveDistance, moveDistanceBefore),
  createPerformanceInfo(3, '서빙 평균 시간', 'm', avgServingTime, avgServingTimeBefore),
  createPerformanceInfo(4, '주행 효율', '%', performance, performanceBefore),
];
```

3. 반복되는 메소드 사용을 줄이기 위해 선언.
- 서버로부터 넘어오는 데이터 중 number 형태로 들어와야 하지만 string 형태로 들어와 type 이슈를 야기.
- parseInt() 메소드를 사용하여 일일이 바꿔줬지만 값을 사용할 때마다 반복적으로 바꿔줘야 하기 때문에 불필요한 리소스 발생.
- 해당 데이터를 number의 형태로 바꾸고 선언하여 반복되는 작업을 최소화.
