### PR TITLE
Refact : Store 페이지 리팩토링 완료

### DIFF
--- a/pages/store/[storeId].tsx
+++ b/pages/store/[storeId].tsx
@@ -1,15 +1,19 @@
+import { GetStaticPaths, GetStaticPropsContext } from 'next';
+import { ParsedUrlQuery } from 'querystring';
+import { TStoreDetail, TStoreInfo, TStoreParams } from '@src/types/store';
 import storeAPI from '@src/api/store';
 import DetailNav from '@src/components/Common/DetailNav';
 import AvailableRobot from '@src/components/Store/AvailableRobot';
 import PeakTime from '@src/components/Store/PeakTime';
 import StoreInfo from '@src/components/Store/StoreInfo';
-import { TStoreDetail, TStoreInfo } from '@src/types/store';
 import styled from '@emotion/styled';
 
-export async function getStaticPaths() {
-  const { data: stores } = await storeAPI.getStores();
+interface IProps {
+  storeDetail: TStoreDetail;
+}
 
-  console.log(stores);
+export const getStaticPaths: GetStaticPaths<ParsedUrlQuery> = async () => {
+  const { data: stores } = await storeAPI.getStores();
 
   const paths = stores.stores.map((store: TStoreInfo) => ({
     params: {
@@ -19,23 +23,27 @@ export async function getStaticPaths() {
 
   return {
     paths,
-    fallback: false,
+    fallback: true,
   };
-}
+};
 
-export async function getStaticProps({ params }: any) {
-  const { data: storeDetail } = await storeAPI.getStores(params.storeId);
+export const getStaticProps = async ({ params }: GetStaticPropsContext<TStoreParams>) => {
+  if (!params) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { storeId } = params;
+
+  const { data: storeDetail } = await storeAPI.getStores(storeId);
 
   return {
     props: {
       storeDetail,
     },
   };
-}
-
-interface IProps {
-  storeDetail: TStoreDetail;
-}
+};
 
 const StoreDetail = ({ storeDetail }: IProps) => {
   const store = storeDetail.stores[0];

--- a/pages/store/index.tsx
+++ b/pages/store/index.tsx
@@ -3,8 +3,10 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { MdArrowForwardIos } from 'react-icons/md';
 import { useRecoilState, useResetRecoilState } from 'recoil';
+import { GetServerSideProps } from 'next';
 import { storeNameState } from '@src/store/storeNameState';
 import { TStore } from '@src/types/store';
+import { TMap } from '@src/types/home';
 import { TDropDown } from '@src/types/common';
 import homeAPI from '@src/api/home';
 import DropDown from '@src/components/Common/DropDown';
@@ -13,7 +15,11 @@ import KakaoMap from '@src/components/Store/KakaoMap';
 import NoriImg from 'public/assets/images/store/nori-image.webp';
 import styled from '@emotion/styled';
 
-export async function getServerSideProps() {
+interface IProps {
+  stores: TStore;
+}
+
+export const getServerSideProps: GetServerSideProps<IProps> = async () => {
   const { data: stores } = await homeAPI.getStores();
 
   return {
@@ -21,37 +27,35 @@ export async function getServerSideProps() {
       stores,
     },
   };
-}
-
-interface IProps {
-  stores: TStore;
-}
+};
 
 const Store = ({ stores }: IProps) => {
   const router = useRouter();
 
-  const [storeName, setStoreName] = useRecoilState(storeNameState);
+  const [storeName, setStoreName] = useRecoilState<string>(storeNameState);
 
   const resetStoreName = useResetRecoilState(storeNameState);
 
-  useEffect(() => {
-    resetStoreName();
-  }, []);
-
-  const dropdownList: TDropDown[] = stores.stores.map(({ map_name: storeName, map_id: storeId }) => ({
-    id: storeId,
-    option: storeName,
-  }));
+  const dropdownList: TDropDown[] = stores.stores.map(
+    ({ map_name: storeName, map_id: storeId }: Pick<TMap, 'map_name' | 'map_id'>) => ({
+      id: storeId,
+      option: storeName,
+    }),
+  );
 
   const pageHandler = (option: string, id: string) => {
     setStoreName(option);
     router.push(`/store/${id}`);
   };
 
+  useEffect(() => {
+    resetStoreName();
+  }, []);
+
   return (
     <StStore>
       <StHeader>
-        <Title title="전체 매장" />
+        <Title title="매장 리스트" />
         <DropDown selected={storeName} list={dropdownList} event={pageHandler} />
       </StHeader>
       <StBody>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import axios, { AxiosResponse } from 'axios';
-import { IErrorCodeObject } from '@src/types/common';
+import { TErrorCodeObject } from '@src/types/common';
 
 export const baseURL: string = process.env.NEXT_PUBLIC_BASE_URL as string;
 
@@ -20,7 +20,7 @@ client.interceptors.response.use((response: AxiosResponse) => {
 
       const errorCode: string = response?.data.code;
 
-      const errorCodeObject: IErrorCodeObject = {
+      const errorCodeObject: TErrorCodeObject = {
         '-1': '서버 내부에서 오류가 발생했습니다.',
         '-2': '필수 인자가 포함되지 않은 경우나 호출 인자값의 데이터 타입이 적절하지 않거나 허용된 범위를 벗어났습니다.',
         '-3': '해당 API에 대한 요청 권한이 없습니다.',

--- a/src/api/robotError.ts
+++ b/src/api/robotError.ts
@@ -1,15 +1,15 @@
 import client from './client';
 import API from './apis';
-import { IDates, IErrorState } from '@src/types/robotError';
+import { TDates, TErrorState } from '@src/types/robotError';
 
 const robotErrorAPI = {
   getErrorList: () => {
     return client.get(`${API.getErrorList}`);
   },
-  postErrorDates: (data: IDates) => {
+  postErrorDates: (data: TDates) => {
     return client.post(`${API.postErrorDates}`, data);
   },
-  getErrorDetail: (data: IErrorState) => {
+  getErrorDetail: (data: TErrorState) => {
     return client.post(`${API.getErrorDetail}`, data);
   },
 };

--- a/src/components/Store/KakaoMap.tsx
+++ b/src/components/Store/KakaoMap.tsx
@@ -45,7 +45,6 @@ const KakaoMap = ({ storeInfo }: IProps) => {
                 clickable={true}
                 onMouseOver={() => {
                   setisOpen(true);
-                  console.log('호버');
                   setInfo({ map_id, map_name, store_lat, store_lng });
                 }}
                 onMouseOut={() => {

--- a/src/components/Store/PeakTime.tsx
+++ b/src/components/Store/PeakTime.tsx
@@ -1,6 +1,7 @@
-import { TServingCounts } from '@src/types/store';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip } from 'chart.js';
+import { TServingCounts } from '@src/types/store';
+import { TArrayOfString } from '@src/types/common';
 import Title from '../Common/Title';
 import Null from '../Common/Null';
 import styled from '@emotion/styled';
@@ -14,9 +15,9 @@ interface IProps {
 const PeakTime = ({ servingCount }: IProps) => {
   const isValid: boolean = servingCount.length !== 0;
 
-  const times: Array<string> = servingCount.map(({ hours }) => `${hours}시`);
+  const times: TArrayOfString = servingCount.map(({ hours }) => `${hours}시`);
 
-  const counts: Array<string> = servingCount.map(({ avg_cnt }) => avg_cnt);
+  const counts: TArrayOfString = servingCount.map(({ avg_cnt }) => avg_cnt);
 
   const options = {
     responsive: true,

--- a/src/components/Store/StoreInfo.tsx
+++ b/src/components/Store/StoreInfo.tsx
@@ -11,13 +11,20 @@ interface IProps {
 const StoreInfo = ({ store }: IProps) => {
   const { img_src, map_name, descirbe, map_id, login, start_node, start_dir, wifi_id, wifi_pw, home } = store;
 
-  const storeInfo = { map_id, login: login.split(',').join(', '), start_node, start_dir, wifi_id, wifi_pw, home };
-
+  const storeInfo = {
+    map_id,
+    login: login.split(', ').join(', '),
+    start_node,
+    start_dir,
+    wifi_id,
+    wifi_pw,
+    home,
+  };
   const isValid = (value: string) => {
     return value ? value : 'No data';
   };
 
-  const STORE_INFO: TStoreDescription[] = Object.entries(storeInfo).map(([key, value], index) => ({
+  const STORE_DESCRIPTION: TStoreDescription[] = Object.entries(storeInfo).map(([key, value], index) => ({
     id: index,
     title: key.charAt(0).toUpperCase() + key.slice(1).replace('_', ' '),
     description: isValid(value),
@@ -37,7 +44,7 @@ const StoreInfo = ({ store }: IProps) => {
           </StColumnBox>
         </StFlexBox>
         <StDevider />
-        {STORE_INFO.map(({ id, title, description }) => (
+        {STORE_DESCRIPTION.map(({ id, title, description }: TStoreDescription) => (
           <StDetailInfo key={id}>
             <StTitle>{title}</StTitle>
             <StDescription>{description}</StDescription>

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -13,6 +13,10 @@ export type TDropDown = {
   option: string;
 };
 
+export type TArrayOfString = Array<string>;
+
+export type TArrayOfNumber = Array<number>;
+
 export type TLayout = {
   children: ReactNode;
 };

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,3 +1,4 @@
+import { ParsedUrlQuery } from 'querystring';
 import { TPerformanceData, TRobot, TRobotState } from './robot';
 import { TErrorNotice, TErrorRiskCounts } from './robotError';
 
@@ -49,4 +50,8 @@ export type TStoreDescription = {
   id: number;
   title: string;
   description: string;
+};
+
+export type TStoreParams = ParsedUrlQuery & {
+  storeId: string;
 };


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Store 페이지 리팩토링 

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. getStaticProps, getStaticPaths 타입 지정 및 에러핸들링
- 더욱 명확한 타입으로 타입 지정 진행.
- 패스에 없는 경로로 접속시 404를 반환하도록 설정.

2. 공통으로 사용될 타입 생성 및 지정
- string 또는 number로 이루어진 배열이 사용될 곳이 많아 이를 common.ts에 각각 TArrayOfString, TArrayOfNumber 라는 이름으로 변수를 생성하고 지정.

3. 타입이 빠진 곳 새롭게 지정