### PR TITLE
Refact : RobotError 페이지 리팩토링 완료

### DIFF
--- a/pages/robotError/[robotErrorId].tsx
+++ b/pages/robotError/[robotErrorId].tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { MutationFunction, useMutation } from 'react-query';
+import { useMutation } from 'react-query';
 import { ParsedUrlQuery } from 'querystring';
 import { TErrorState } from '@src/types/robotError';
 import errorAPI from '@src/api/robotError';
@@ -16,12 +16,13 @@ const RobotErrorDetail = () => {
 
   const requestData = router.query as ParsedUrlQuery & TErrorState;
 
-  const mutationFn: MutationFunction<any, TErrorState> = async (data: TErrorState) => {
-    const { data: errorDetail } = await errorAPI.getErrorDetail(data);
-    return errorDetail;
-  };
-
-  const { mutate: postErrorState, data: errorDetail } = useMutation(mutationFn, { mutationKey: 'errorDetail' });
+  const { mutate: postErrorState, data: errorDetail } = useMutation(
+    async (data: TErrorState) => {
+      const { data: errorDetail } = await errorAPI.getErrorDetail(data);
+      return errorDetail;
+    },
+    { mutationKey: 'errorDetail' },
+  );
 
   useEffect(() => {
     if (Object.keys(requestData).length !== 0) {

--- a/src/api/robotError.ts
+++ b/src/api/robotError.ts
@@ -1,12 +1,12 @@
 import client from './client';
 import API from './apis';
-import { TDates, TErrorState } from '@src/types/robotError';
+import { TDateData, TErrorState } from '@src/types/robotError';
 
 const robotErrorAPI = {
   getErrorList: () => {
     return client.get(`${API.getErrorList}`);
   },
-  postErrorDates: (data: TDates) => {
+  postErrorDates: (data: TDateData) => {
     return client.post(`${API.postErrorDates}`, data);
   },
   getErrorDetail: (data: TErrorState) => {

--- a/src/components/RobotError/Count.tsx
+++ b/src/components/RobotError/Count.tsx
@@ -22,7 +22,7 @@ const Count = ({ type, week, month }: IProps) => {
       </StHeader>
       <StBody>
         <StFlexBox>
-          {COUNT_INFO.map(({ id, title, description }) => (
+          {COUNT_INFO.map(({ id, title, description }: TCountInfo) => (
             <StCountBox key={id}>
               <StDescription>{description}</StDescription>
               <StPeriod>{title}</StPeriod>

--- a/src/components/RobotError/ErrorInfo.tsx
+++ b/src/components/RobotError/ErrorInfo.tsx
@@ -27,7 +27,7 @@ const ErrorInfo = ({ errorInfo }: IProps) => {
         <Title title="에러 정보" />
       </StHeader>
       <StBody>
-        {ERROR_INFO.map(({ id, title, description }) => (
+        {ERROR_INFO.map(({ id, title, description }: TCountInfo) => (
           <StFlexBox key={id}>
             <StTitle>{title} : </StTitle>
             <StDescription>{description ? description : '등록되지 않은 데이터입니다'}</StDescription>

--- a/src/components/RobotError/ErrorList.tsx
+++ b/src/components/RobotError/ErrorList.tsx
@@ -14,7 +14,9 @@ interface IProps {
 const ErrorList = ({ errorList, mutateLoading }: IProps) => {
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const { data, isLoading: scrollLoading } = useInfiniteScroll(errorList, observerRef);
+  const { data: filteredErrorList, isLoading: scrollLoading } = useInfiniteScroll(errorList, observerRef);
+
+  const isValid: boolean = filteredErrorList.length !== 0;
 
   return (
     <StErrorList>
@@ -24,17 +26,22 @@ const ErrorList = ({ errorList, mutateLoading }: IProps) => {
       <StBody>
         {mutateLoading ? (
           <Spinner />
-        ) : data.length !== 0 ? (
-          data.map((cur: TErrorState, idx: number) => <Error key={idx} {...cur} />)
         ) : (
-          <StNull>조건에 맞는 에러가 존재하지 않습니다</StNull>
+          <>
+            {isValid ? (
+              filteredErrorList.map((error: TErrorState, idx: number) => <Error key={idx} {...error} />)
+            ) : (
+              <StNull>조건에 맞는 에러가 존재하지 않습니다</StNull>
+            )}
+
+            {scrollLoading && (
+              <StSpinnerBox>
+                <Spinner />
+              </StSpinnerBox>
+            )}
+            <div ref={observerRef} />
+          </>
         )}
-        {scrollLoading && (
-          <StSpinnerBox>
-            <Spinner />
-          </StSpinnerBox>
-        )}
-        <div ref={observerRef} />
       </StBody>
     </StErrorList>
   );

--- a/src/components/RobotError/RelatedErrors.tsx
+++ b/src/components/RobotError/RelatedErrors.tsx
@@ -14,7 +14,7 @@ const RelatedErrors = ({ relatedErrors }: IProps) => {
       </StHeader>
       <StBody>
         {relatedErrors &&
-          relatedErrors.map(({ created_at, error_id, error_type }) => (
+          relatedErrors.map(({ created_at, error_id, error_type }: TErrorState) => (
             <StErrorBox key={error_id}>
               <StFlexBox>
                 <StTitle>Error type : </StTitle>

--- a/src/components/RobotError/SolutionList.tsx
+++ b/src/components/RobotError/SolutionList.tsx
@@ -8,17 +8,19 @@ interface IProps {
 }
 
 const SolutionList = ({ solutionList }: IProps) => {
+  const isValid: boolean = solutionList.length === 0;
+
   return (
     <StSolutionList>
       <StHeader>
         <Title title="해당 에러와 관련된 해결 방법" />
       </StHeader>
       <StBody>
-        {solutionList && solutionList.length === 0 ? (
+        {solutionList && isValid ? (
           <Null />
         ) : (
           solutionList &&
-          solutionList.map(({ error_id, manager, content }) => (
+          solutionList.map(({ error_id, manager, content }: TErrorSolution) => (
             <StSolution key={error_id}>
               <StFlexBox>
                 <StTitle>담당자 : </StTitle>

--- a/src/types/robotError.ts
+++ b/src/types/robotError.ts
@@ -48,7 +48,7 @@ export type TErrorRiskCounts = {
   minor: string;
 };
 
-export type TDates = {
+export type TDateData = {
   start_date: string;
   end_date: string;
   map_id: number;

--- a/src/utils/getDay.ts
+++ b/src/utils/getDay.ts
@@ -1,0 +1,3 @@
+const date = new Date();
+
+export const getDay = date.getDate();

--- a/src/utils/getMonth.ts
+++ b/src/utils/getMonth.ts
@@ -1,0 +1,3 @@
+const date = new Date();
+
+export const getMonth = date.getMonth();

--- a/src/utils/getYear.ts
+++ b/src/utils/getYear.ts
@@ -1,0 +1,3 @@
+const date = new Date();
+
+export const getYear = date.getFullYear();


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- RobotError 페이지 리팩토링

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 불필요한 통신 최소화
- 불필요한 통신 횟수를 최소화 하기 위해 기존 가게들의 이름 리스트를 store api를 통해 받아오는 것이 아닌 상수 데이터로 처리.

```
  const createStoreName = (id: string, option: string): TStoreName => {
    return { id, option };
  };

  const STORE_NAME: TStoreName[] = [
    createStoreName('0', '전체매장'),
    createStoreName('1', '향동 노리 배달쿡'),
    createStoreName('2', '연신내 더피플버거'),
    createStoreName('3', '오산 공유주방'),
    createStoreName('4', '차세대 융합 기술 연구원'),
    createStoreName('5', '더티프라이'),
    createStoreName('6', '노원 발란'),
  ];
```

2. utils 함수 추가
- robotError 페이지 접속시 현재 날짜에서 6일 전을 계산해 달력의 시작값을 설정.
- useState보다 위에서 date를 생성하고 선언했기 때문에 react-hook 룰을 위배하는 이슈가 발생.
- 다른 컴포넌트에서도 같은 형식으로 사용되고 있기 때문에 재사용성을 높이기 위해서라도 연도, 달, 일을 구하는 함수를 utils 함수로 빼고 import 해오는 방식으로 전환

3. 타입 재지정