### PR TITLE
Fix : 에러리스트 에러 타입 수정 및 Null 컴포넌트 위치 조정

### DIFF
--- a/pages/robot/index.tsx
+++ b/pages/robot/index.tsx
@@ -168,7 +168,6 @@ const StDropDownBox = styled.div`
 `;
 
 const StBody = styled.main`
-  position: relative;
   margin-top: 20px;
   display: flex;
   justify-content: center;

--- a/src/components/Common/Error.tsx
+++ b/src/components/Common/Error.tsx
@@ -28,7 +28,7 @@ const Error = ({
     <StError onClick={pageHandler}>
       <StHeader color={risk_degree} />
       <StBody>
-        <StErrorMessage>{error_msg ? error_msg.split(',').join(', ') : '확인되지 않은 에러입니다.'}</StErrorMessage>
+        <StErrorMessage>{error_msg ? error_msg : '확인되지 않은 에러입니다.'}</StErrorMessage>
         <StFlexBox>
           <StStoreName>{k_map_name ? k_map_name : error_type}</StStoreName>
           <StTime>{created_at}</StTime>
@@ -65,7 +65,7 @@ const StError = styled.div`
 const StHeader = styled.header<{ color: string }>`
   width: 5%;
   height: 70px;
-  background: ${({ theme, color }) => (color ? theme.color[color] : theme.color.stroke)};
+  background: ${({ theme, color }) => (color ? theme.color[color.toLowerCase()] : theme.color.stroke)};
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
 `;
@@ -79,6 +79,11 @@ const StBody = styled.main`
 `;
 
 const StErrorMessage = styled.p`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 270px;
+  height: 20px;
   font-size: 14px;
 `;
 

--- a/src/components/Home/RecentError/RecentError.tsx
+++ b/src/components/Home/RecentError/RecentError.tsx
@@ -19,11 +19,11 @@ const RecentError = () => {
 
   const riskDegree: TRiskDegree = recentErrorList.reduce(
     (acc: TRiskDegree, { risk_degree }) => {
-      acc['all'] = acc['all'] + 1;
+      acc['ALL'] = acc['ALL'] + 1;
       acc[risk_degree] = acc[risk_degree] + 1;
       return acc;
     },
-    { all: 0, minor: 0, major: 0, critical: 0 },
+    { ALL: 0, MINOR: 0, MAJOR: 0, CRITICAL: 0 },
   );
 
   const riskDegreeList: TRiskDegreeList[] = Object.entries(riskDegree).map(([degree, count], id) => ({
@@ -74,6 +74,7 @@ const RecentError = () => {
     },
     {
       onSuccess: ({ error_notice: recentErrors }) => {
+        console.log(recentErrors);
         return setRecentErrors(recentErrors);
       },
       refetchInterval: refetchTime(),
@@ -88,7 +89,7 @@ const RecentError = () => {
           {riskDegreeList.map(({ id, degree }: TRiskDegreeList) => (
             <StFlexBox key={id}>
               <StColor color={degree} />
-              <StDegree>{degree[0].toUpperCase() + degree.slice(1)}</StDegree>
+              <StDegree>{degree}</StDegree>
             </StFlexBox>
           ))}
         </StDegreeBox>
@@ -130,8 +131,8 @@ const StFlexBox = styled.div`
 const StColor = styled.div<{ color: string }>`
   width: 10px;
   height: 10px;
-  background: ${({ theme, color }) => theme.color[color]};
-  border: ${({ color }) => color === 'all' && '1px solid black'};
+  background: ${({ theme, color }) => theme.color[color.toLowerCase()]};
+  border: ${({ color }) => color === 'ALL' && '1px solid black'};
   border-radius: 10px;
 `;
 

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -36,10 +36,10 @@ export type TRiskDegreeList = {
 
 export type TRiskDegree = {
   [key: string]: number;
-  all: number;
-  minor: number;
-  major: number;
-  critical: number;
+  ALL: number;
+  MINOR: number;
+  MAJOR: number;
+  CRITICAL: number;
 };
 
 export type TRobotState = {


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 에러리스트 에러 타입 수정 및 Null 컴포넌트 위치 조정

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 에러리스트 에러 타입 수정
- Home 페이지의 RecentErrors 컴포넌트에서 서버에서 보내주는 에러 타입이 대문자로 변경.
- 에러 타입이 대문자로 변경 됨에 따라 누적 함수가 이를 제대로 인지하지 못하고 엉뚱한 값으로 계산하여 에러가 발생.
- 해당 함수에서 사용하는 all, minor, major, critical 를 대문자로 변경하여 제대로 값을 계산하도록 수정.

2. 글자 길이가 일정 수를 넘어가면 아래로 밀리는 현상 
- text-overflow: ellipsis css 속성을 이용하여 해결.

3. Null 컴포넌트 위치 조정
- Robot 페이지에서 검색 결과가 없을 경우 Null 컴포넌트를 반환하도록 되어 있는데, Null 컴포넌트의 위치가 화면 정중앙이 아닌
해당 body를 기준으로 중앙에 위치하는 버그가 발생.
- body의 relative 속성을 삭제함으로써 해결.