### PR TITLE
Refact : 고정 url 이동은 Link로 변경

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,19 +1,15 @@
-import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
+import Link from 'next/link';
 
 const Custom404 = () => {
-  const router = useRouter();
-
-  const pageHandler = () => {
-    router.push('/');
-  };
-
   return (
     <StCustom404>
       <StHeader>요청하신 페이지를 찾을 수 없습니다 :(</StHeader>
       <StBody>404 ERROR</StBody>
       <StFooter>
-        <StBack onClick={pageHandler}>홈으로 돌아가기</StBack>
+        <Link href={'/'}>
+          <StBack>홈으로 돌아가기</StBack>
+        </Link>
       </StFooter>
     </StCustom404>
   );

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,19 +1,15 @@
-import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
+import Link from 'next/link';
 
 const Custom500 = () => {
-  const router = useRouter();
-
-  const pageHandler = () => {
-    router.push('/');
-  };
-
   return (
     <StCustom500>
       <StHeader>서버에 오류가 발생했습니다 :(</StHeader>
       <StBody>500 ERROR</StBody>
       <StFooter>
-        <StBack onClick={pageHandler}>홈으로 돌아가기</StBack>
+        <Link href={'/'}>
+          <StBack>홈으로 돌아가기</StBack>
+        </Link>
       </StFooter>
     </StCustom500>
   );

--- a/pages/Error.tsx
+++ b/pages/Error.tsx
@@ -1,22 +1,21 @@
+import Link from 'next/link';
 import { useRouter } from 'next/router';
-import styled from '@emotion/styled';
 import { ParsedUrlQuery } from 'querystring';
+import styled from '@emotion/styled';
 
 const Error = () => {
-  const router = useRouter();
+  const { query } = useRouter();
 
-  const pageHandler = () => {
-    router.push('/');
-  };
-
-  const { errorDescription, errorCode } = router.query as ParsedUrlQuery;
+  const { errorDescription, errorCode } = query as ParsedUrlQuery;
 
   return (
     <StError>
       <StHeader>{errorDescription}</StHeader>
       <StBody>Error Code {errorCode}</StBody>
       <StFooter>
-        <StBack onClick={pageHandler}>홈으로 돌아가기</StBack>
+        <Link href={'/'}>
+          <StBack>홈으로 돌아가기</StBack>
+        </Link>
       </StFooter>
     </StError>
   );

--- a/src/components/Common/BottomNav.tsx
+++ b/src/components/Common/BottomNav.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
@@ -10,18 +11,14 @@ import { navState } from '@src/store/navState';
 import styled from '@emotion/styled';
 
 const BottomNav = () => {
-  const router = useRouter();
+  const { pathname } = useRouter();
 
   const [nav, setNav] = useRecoilState<string>(navState);
 
-  const currentPath: string = router.pathname.split('/')[1];
+  const currentPath: string = pathname.split('/')[1];
 
   const navHandler = () => {
     currentPath === '' ? setNav('/') : setNav(`/${currentPath}`);
-  };
-
-  const pageHandler = (path: string) => {
-    router.push(path);
   };
 
   useEffect(() => {
@@ -63,8 +60,8 @@ const BottomNav = () => {
     <StBottomNav>
       <StBody>
         {NAV.map(({ id, name, path, active, disabled }: TNav) => (
-          <StFlexBox key={id} onClick={() => pageHandler(path)}>
-            {nav === path ? active : disabled}
+          <StFlexBox key={id}>
+            <Link href={path}>{nav === path ? active : disabled}</Link>
             <StName isSame={nav === path}>{name}</StName>
           </StFlexBox>
         ))}


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Next/link 태그가 사용자의 화면 (뷰포트)에 보이면 해당 페이지의 번들파일을 서버에 요청하여 prefetch하는 이점을 누리기 위해 Link로 전환

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 고정 url은 Link, 동적으로 일어나는 페이지 전환의 경우 router.push 사용
- SEO를 신경쓰지 않아도 되는 프로젝트이기 때문에 Link를 사용하지 않았으나 Next/link 태그가 사용자의 화면 (뷰포트)에 보이면 해당 페이지의 번들파일을 서버에 요청하여 prefetch하기 때문에 미리 가져온 번들을 통해 페이지 이동을 빠르게 할 수 있다.
- 고정된 url은 Link, 동적 url은 router.push를 이용하여 구현
